### PR TITLE
Add Http4s Assets interpreter

### DIFF
--- a/akka-http/client/src/main/scala/endpoints4s/akkahttp/client/StatusCodes.scala
+++ b/akka-http/client/src/main/scala/endpoints4s/akkahttp/client/StatusCodes.scala
@@ -23,6 +23,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = AkkaStatusCodes.AlreadyReported
   override def IMUsed = AkkaStatusCodes.IMUsed
 
+  def NotModified = AkkaStatusCodes.NotModified
+
   def BadRequest = AkkaStatusCodes.BadRequest
   def Unauthorized = AkkaStatusCodes.Unauthorized
   override def PaymentRequired = AkkaStatusCodes.PaymentRequired

--- a/akka-http/client/src/main/scala/endpoints4s/akkahttp/client/StatusCodes.scala
+++ b/akka-http/client/src/main/scala/endpoints4s/akkahttp/client/StatusCodes.scala
@@ -23,7 +23,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = AkkaStatusCodes.AlreadyReported
   override def IMUsed = AkkaStatusCodes.IMUsed
 
-  def NotModified = AkkaStatusCodes.NotModified
+  override def NotModified = AkkaStatusCodes.NotModified
 
   def BadRequest = AkkaStatusCodes.BadRequest
   def Unauthorized = AkkaStatusCodes.Unauthorized

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/StatusCodes.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/StatusCodes.scala
@@ -23,6 +23,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = AkkaStatusCodes.AlreadyReported
   override def IMUsed = AkkaStatusCodes.IMUsed
 
+  def NotModified = AkkaStatusCodes.NotModified
+
   def BadRequest = AkkaStatusCodes.BadRequest
   def Unauthorized = AkkaStatusCodes.Unauthorized
   override def PaymentRequired = AkkaStatusCodes.PaymentRequired

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/StatusCodes.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/StatusCodes.scala
@@ -23,7 +23,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = AkkaStatusCodes.AlreadyReported
   override def IMUsed = AkkaStatusCodes.IMUsed
 
-  def NotModified = AkkaStatusCodes.NotModified
+  override def NotModified = AkkaStatusCodes.NotModified
 
   def BadRequest = AkkaStatusCodes.BadRequest
   def Unauthorized = AkkaStatusCodes.Unauthorized

--- a/algebras/algebra/src/main/scala/endpoints4s/algebra/ServerAssets.scala
+++ b/algebras/algebra/src/main/scala/endpoints4s/algebra/ServerAssets.scala
@@ -1,0 +1,20 @@
+package endpoints4s.algebra
+
+trait ServerAssets extends Assets {
+
+  type AssetContent
+
+  def notFoundAssetResponse: AssetResponse
+
+  def foundAssetResponse(
+      content: AssetContent,
+      contentLength: Long,
+      fileName: String,
+      isGzipped: Boolean,
+      isExpired: Boolean,
+      lastModifiedSeconds: Long
+  ): AssetResponse
+
+  def noopAssetContent: AssetContent
+
+}

--- a/algebras/algebra/src/main/scala/endpoints4s/algebra/StatusCodes.scala
+++ b/algebras/algebra/src/main/scala/endpoints4s/algebra/StatusCodes.scala
@@ -47,6 +47,10 @@ trait StatusCodes {
   /** @group operations */
   def IMUsed: StatusCode = unsupportedInterpreter("1.1.0")
 
+  // 3xx Redirection
+  /** @group operations */
+  def NotModified: StatusCode
+
   // 4xx Client Error
   /**
     * @note You should use the `badRequest` constructor provided by the [[endpoints4s.algebra.Responses]]

--- a/algebras/algebra/src/main/scala/endpoints4s/algebra/StatusCodes.scala
+++ b/algebras/algebra/src/main/scala/endpoints4s/algebra/StatusCodes.scala
@@ -49,7 +49,7 @@ trait StatusCodes {
 
   // 3xx Redirection
   /** @group operations */
-  def NotModified: StatusCode
+  def NotModified: StatusCode = unsupportedInterpreter("1.2.0")
 
   // 4xx Client Error
   /**

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/AssetsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/AssetsTestApi.scala
@@ -1,6 +1,6 @@
 package endpoints4s.algebra
 
-trait AssetsTestApi extends EndpointsTestApi with Assets {
+trait AssetsTestApi extends EndpointsTestApi with ServerAssets {
 
   val assetEndpoint: Endpoint[AssetRequest, AssetResponse] =
     assetsEndpoint(path / "assets" / assetSegments())

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/AssetsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/AssetsTestApi.scala
@@ -1,5 +1,6 @@
 package endpoints4s.algebra
 
+import server.ServerAssets
 trait AssetsTestApi extends EndpointsTestApi with ServerAssets {
 
   val assetEndpoint: Endpoint[AssetRequest, AssetResponse] =

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/AssetsTestApi.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/AssetsTestApi.scala
@@ -1,0 +1,8 @@
+package endpoints4s.algebra
+
+trait AssetsTestApi extends EndpointsTestApi with Assets {
+
+  val assetEndpoint: Endpoint[AssetRequest, AssetResponse] =
+    assetsEndpoint(path / "assets" / assetSegments())
+
+}

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/AssetsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/AssetsTestSuite.scala
@@ -1,7 +1,11 @@
 package endpoints4s.algebra.server
 
-import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model.HttpMethods.{GET}
 import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.{`Last-Modified`, `If-Modified-Since`, `Content-Type`}
+import akka.http.scaladsl.model.DateTime
+import akka.http.scaladsl.model.ContentType
+import akka.http.scaladsl.model.MediaTypes
 
 trait AssetsTestSuite[T <: endpoints4s.algebra.AssetsTestApi] extends ServerAssetTest[T] {
 
@@ -27,6 +31,55 @@ trait AssetsTestSuite[T <: endpoints4s.algebra.AssetsTestApi] extends ServerAsse
         whenReady(send(request)) {
           case (response, entity) =>
             assert(response.status.intValue() == 404)
+            ()
+        }
+      }
+    }
+
+    "send Last-Modified header (rfc7232)" in {
+      serveAssetsEndpointFromPath(serverApi.assetEndpoint, Some("/assets")) { port =>
+        val request =
+          HttpRequest(method = GET, uri = s"http://localhost:$port/assets/asset1.txt")
+
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(
+              response
+                .header[`Last-Modified`]
+                .nonEmpty
+            )
+            ()
+        }
+      }
+    }
+
+    "evaluate If-Modified-Since header (rfc7232)" in {
+      serveAssetsEndpointFromPath(serverApi.assetEndpoint, Some("/assets")) { port =>
+        val request =
+          HttpRequest(method = GET, uri = s"http://localhost:$port/assets/asset1.txt").withHeaders(
+            `If-Modified-Since`(DateTime.apply(2020, 7, 26))
+          )
+
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 304)
+            ()
+        }
+      }
+    }
+
+    "send correct Content-Type header" in {
+      serveAssetsEndpointFromPath(serverApi.assetEndpoint, Some("/assets")) { port =>
+        val request =
+          HttpRequest(method = GET, uri = s"http://localhost:$port/assets/asset1.txt")
+
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(
+              response
+                .header[`Content-Type`]
+                .contains(`Content-Type`(ContentType.WithMissingCharset(MediaTypes.`text/plain`)))
+            )
             ()
         }
       }

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/AssetsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/AssetsTestSuite.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.DateTime
 import akka.http.scaladsl.model.ContentType
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.headers.HttpEncodings
+
 trait AssetsTestSuite[T <: endpoints4s.algebra.AssetsTestApi] extends ServerAssetTest[T] {
 
   "Assets interpreter" should {

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/AssetsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/AssetsTestSuite.scala
@@ -1,0 +1,36 @@
+package endpoints4s.algebra.server
+
+import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model.HttpRequest
+
+trait AssetsTestSuite[T <: endpoints4s.algebra.AssetsTestApi] extends ServerAssetTest[T] {
+
+  "Assets interpreter" should {
+    "respond OK for found asset" in {
+      serveAssetsEndpointFromPath(serverApi.assetEndpoint, Some("/assets")) { port =>
+        val request =
+          HttpRequest(method = GET, uri = s"http://localhost:$port/assets/asset1.txt")
+
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 200)
+            ()
+        }
+      }
+    }
+
+    "respond NotFound for not found asset" in {
+      serveAssetsEndpointFromPath(serverApi.assetEndpoint, Some("/assets")) { port =>
+        val request =
+          HttpRequest(method = GET, uri = s"http://localhost:$port/assets/non-existing-asset.txt")
+
+        whenReady(send(request)) {
+          case (response, entity) =>
+            assert(response.status.intValue() == 404)
+            ()
+        }
+      }
+    }
+  }
+
+}

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssetTest.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssetTest.scala
@@ -1,0 +1,12 @@
+package endpoints4s.algebra.server
+
+import endpoints4s.algebra
+
+trait ServerAssetTest[T <: algebra.Endpoints with algebra.Assets] extends ServerTestBase[T] {
+
+  def serveAssetsEndpointFromPath(
+      endpoint: serverApi.Endpoint[serverApi.AssetRequest, serverApi.AssetResponse],
+      pathPrefix: Option[String]
+  )(runTests: Int => Unit): Unit
+
+}

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssetTest.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssetTest.scala
@@ -2,11 +2,11 @@ package endpoints4s.algebra.server
 
 import endpoints4s.algebra
 
-trait ServerAssetTest[T <: algebra.Endpoints with algebra.Assets] extends ServerTestBase[T] {
+trait ServerAssetTest[T <: algebra.Endpoints with algebra.ServerAssets] extends ServerTestBase[T] {
 
-  def serveAssetsEndpointFromPath(
+  def serveAssetsEndpoint(
       endpoint: serverApi.Endpoint[serverApi.AssetRequest, serverApi.AssetResponse],
-      pathPrefix: Option[String]
+      response: => serverApi.AssetResponse
   )(runTests: Int => Unit): Unit
 
 }

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssetTest.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssetTest.scala
@@ -2,7 +2,7 @@ package endpoints4s.algebra.server
 
 import endpoints4s.algebra
 
-trait ServerAssetTest[T <: algebra.Endpoints with algebra.ServerAssets] extends ServerTestBase[T] {
+trait ServerAssetTest[T <: algebra.Endpoints with ServerAssets] extends ServerTestBase[T] {
 
   def serveAssetsEndpoint(
       endpoint: serverApi.Endpoint[serverApi.AssetRequest, serverApi.AssetResponse],

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssets.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ServerAssets.scala
@@ -1,4 +1,6 @@
-package endpoints4s.algebra
+package endpoints4s.algebra.server
+
+import endpoints4s.algebra.Assets
 
 trait ServerAssets extends Assets {
 

--- a/http4s/client/src/main/scala/endpoints4s/http4s/client/StatusCodes.scala
+++ b/http4s/client/src/main/scala/endpoints4s/http4s/client/StatusCodes.scala
@@ -23,7 +23,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = Http4sStatus.AlreadyReported
   override def IMUsed = Http4sStatus.IMUsed
 
-  def NotModified = Http4sStatus.NotModified
+  override def NotModified = Http4sStatus.NotModified
   def BadRequest = Http4sStatus.BadRequest
   def Unauthorized = Http4sStatus.Unauthorized
   override def PaymentRequired = Http4sStatus.PaymentRequired

--- a/http4s/client/src/main/scala/endpoints4s/http4s/client/StatusCodes.scala
+++ b/http4s/client/src/main/scala/endpoints4s/http4s/client/StatusCodes.scala
@@ -23,6 +23,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = Http4sStatus.AlreadyReported
   override def IMUsed = Http4sStatus.IMUsed
 
+  def NotModified = Http4sStatus.NotModified
   def BadRequest = Http4sStatus.BadRequest
   def Unauthorized = Http4sStatus.Unauthorized
   override def PaymentRequired = Http4sStatus.PaymentRequired

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
@@ -12,6 +12,9 @@ import org.http4s._
 trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
   val DefaultBufferSize = 10240
 
+  // Digests are unsupported.
+  def digests: Map[String, String] = Map.empty
+
   case class AssetRequest(
       assetPath: AssetPath,
       isGzipSupported: Boolean,

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
@@ -1,0 +1,161 @@
+package endpoints4s.http4s.server
+
+import java.net.URL
+
+import cats.effect.{Blocker, ContextShift}
+import cats.implicits._
+import endpoints4s.algebra.Documentation
+import endpoints4s.{Invalid, Valid, algebra}
+import fs2.io._
+import org.http4s.headers._
+import org.http4s._
+
+trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
+  val DefaultBufferSize = 10240
+
+  case class AssetRequest(
+      assetPath: AssetPath,
+      isGzipSupported: Boolean,
+      ifModifiedSince: Option[HttpDate]
+  )
+
+  case class AssetPath(path: Seq[String], digest: String, name: String)
+
+  sealed trait AssetResponse
+  object AssetResponse {
+    case object NotFound extends AssetResponse
+    case class Found(
+        data: fs2.Stream[Effect, Byte],
+        contentLength: Long,
+        lastModified: Option[HttpDate],
+        mediaType: Option[MediaType],
+        isGzipped: Boolean,
+        expired: Boolean
+    ) extends AssetResponse
+  }
+
+  override def assetSegments(
+      name: String,
+      docs: Documentation
+  ): Path[AssetPath] =
+    (segments: List[String]) =>
+      segments.reverse match {
+        case s :: p =>
+          val i = s.lastIndexOf('-')
+          if (i > 0) {
+            val (name, digest) = s.splitAt(i)
+            Some((Valid(AssetPath(p.reverse, digest.drop(1), name)), Nil))
+          } else Some((Invalid("Invalid asset segments"), Nil))
+        case Nil => None
+      }
+
+  private lazy val gzipSupport: RequestHeaders[Boolean] =
+    headers => Valid(headers.get(`Accept-Encoding`).exists(_.satisfiedBy(ContentCoding.gzip)))
+
+  private lazy val ifModifiedSince: RequestHeaders[Option[HttpDate]] =
+    headers => Valid(headers.get(`If-Modified-Since`).map(_.date))
+
+  override def assetsEndpoint(
+      url: Url[AssetPath],
+      docs: Documentation,
+      notFoundDocs: Documentation
+  ): Endpoint[AssetRequest, AssetResponse] = {
+    val assetRequest =
+      requestPartialInvariantFunctor
+        .xmap(
+          request(
+            Get,
+            url,
+            headers = requestHeadersSemigroupal.product(gzipSupport, ifModifiedSince)
+          ),
+          (t: (AssetPath, Boolean, Option[HttpDate])) => AssetRequest(t._1, t._2, t._3),
+          (assetRequest: AssetRequest) =>
+            (assetRequest.assetPath, assetRequest.isGzipSupported, assetRequest.ifModifiedSince)
+        )
+
+    endpoint(assetRequest, assetResponse)
+  }
+
+  private val assetResponse: Response[AssetResponse] = {
+    case AssetResponse.NotFound                    => Response(NotFound)
+    case AssetResponse.Found(_, _, _, _, _, false) => Response(NotModified)
+    case AssetResponse.Found(data, length, lastModified, mediaType, isGzipped, true) =>
+      val lastModifiedHeader = lastModified.map(`Last-Modified`(_))
+      val contentTypeHeader = mediaType.map(`Content-Type`(_))
+      val contentCodingHeader =
+        if (isGzipped) Some(`Content-Encoding`(ContentCoding.gzip)) else None
+      val contentLengthHeader =
+        `Content-Length`.fromLong(length).getOrElse(`Transfer-Encoding`(TransferCoding.chunked))
+
+      val headers = Headers(
+        contentLengthHeader :: List(
+          contentTypeHeader,
+          contentCodingHeader,
+          lastModifiedHeader
+        ).flatten
+      )
+
+      Response(
+        headers = headers,
+        body = data
+      )
+
+  }
+
+  private def toUrl(
+      pathPrefix: Option[String],
+      assetRequest: AssetRequest
+  ): Option[(URL, Boolean)] = {
+    val assetInfo = assetRequest.assetPath
+    val path =
+      if (assetInfo.path.nonEmpty)
+        assetInfo.path.mkString("", "/", s"/${assetInfo.name}")
+      else assetInfo.name
+    val hasDigest = digests.get(path).contains(assetInfo.digest)
+
+    lazy val resourcePath = pathPrefix.getOrElse("") ++ s"/$path"
+    def nonGzippedAsset = Option(getClass.getResource(resourcePath)).map((_, false))
+
+    if (hasDigest && assetRequest.isGzipSupported)
+      Option(getClass.getResource(s"$resourcePath.gz"))
+        .map((_, true))
+        .orElse(nonGzippedAsset)
+    else if (hasDigest) nonGzippedAsset
+    else None
+  }
+
+  private def toMediaType(name: String): Option[MediaType] =
+    name.lastIndexOf('.') match {
+      case -1 => None
+      case i  => MediaType.forExtension(name.substring(i + 1))
+    }
+
+  def assetsResources(
+      pathPrefix: Option[String] = None,
+      blocker: Blocker
+  )(implicit cs: ContextShift[Effect]): AssetRequest => AssetResponse =
+    assetRequest =>
+      toUrl(pathPrefix, assetRequest)
+        .map {
+          case (url, isGzipped) =>
+            val urlConn = url.openConnection
+
+            val ifModifiedSince = assetRequest.ifModifiedSince
+            val lastModified = HttpDate.fromEpochSecond(urlConn.getLastModified / 1000).toOption
+            val expired = (ifModifiedSince, lastModified).mapN(_ < _).getOrElse(true)
+            val contentLength = urlConn.getContentLengthLong
+            val mediaType = toMediaType(assetRequest.assetPath.name)
+            val data =
+              readInputStream[Effect](Effect.delay(url.openStream), DefaultBufferSize, blocker)
+
+            AssetResponse.Found(
+              data,
+              contentLength,
+              lastModified,
+              mediaType,
+              isGzipped,
+              expired
+            )
+        }
+        .getOrElse(AssetResponse.NotFound)
+}

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
@@ -100,7 +100,7 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
             url,
             headers = requestHeadersSemigroupal.product(gzipSupport, ifModifiedSince)
           ),
-          (t: (AssetPath, Boolean, Option[HttpDate])) => AssetRequest(t._1, t._2, t._3),
+          AssetRequest.tupled,
           (assetRequest: AssetRequest) =>
             (assetRequest.assetPath, assetRequest.isGzipSupported, assetRequest.ifModifiedSince)
         )

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
@@ -9,7 +9,7 @@ import fs2.io._
 import org.http4s.headers._
 import org.http4s._
 
-trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
+trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
   val DefaultBufferSize = 10240
 
   case class AssetRequest(
@@ -33,12 +33,8 @@ trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
     ) extends AssetResponse
   }
 
-  type AssetContent = fs2.Stream[Effect, Byte]
-
-  def notFoundAssetResponse = AssetResponse.NotFound
-
   def foundAssetResponse(
-      content: AssetContent,
+      content: fs2.Stream[Effect, Byte],
       contentLength: Long,
       fileName: String,
       isGzipped: Boolean,
@@ -53,8 +49,6 @@ trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
       isGzipped,
       isExpired
     )
-
-  def noopAssetContent = fs2.Stream.empty
 
   def assetSegments(
       name: String,
@@ -182,6 +176,6 @@ trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
               lastModifiedSeconds = lastModifiedSeconds
             )
         }
-        .getOrElse(notFoundAssetResponse)
+        .getOrElse(AssetResponse.NotFound)
 
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/StatusCodes.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/StatusCodes.scala
@@ -23,7 +23,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = Http4sStatus.AlreadyReported
   override def IMUsed = Http4sStatus.IMUsed
 
-  def NotModified = Http4sStatus.NotModified
+  override def NotModified = Http4sStatus.NotModified
   def BadRequest = Http4sStatus.BadRequest
   def Unauthorized = Http4sStatus.Unauthorized
   override def PaymentRequired = Http4sStatus.PaymentRequired

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/StatusCodes.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/StatusCodes.scala
@@ -23,6 +23,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = Http4sStatus.AlreadyReported
   override def IMUsed = Http4sStatus.IMUsed
 
+  def NotModified = Http4sStatus.NotModified
   def BadRequest = Http4sStatus.BadRequest
   def Unauthorized = Http4sStatus.Unauthorized
   override def PaymentRequired = Http4sStatus.PaymentRequired
@@ -54,5 +55,4 @@ trait StatusCodes extends algebra.StatusCodes {
 
   def InternalServerError = Http4sStatus.InternalServerError
   def NotImplemented = Http4sStatus.NotImplemented
-  def NotModified = Http4sStatus.NotModified
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/StatusCodes.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/StatusCodes.scala
@@ -54,4 +54,5 @@ trait StatusCodes extends algebra.StatusCodes {
 
   def InternalServerError = Http4sStatus.InternalServerError
   def NotImplemented = Http4sStatus.NotImplemented
+  def NotModified = Http4sStatus.NotModified
 }

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/AssetsResourcesTest.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/AssetsResourcesTest.scala
@@ -1,0 +1,51 @@
+package endpoints4s.http4s.server
+
+import endpoints4s.algebra.server.ServerTestBase
+import org.http4s.HttpDate
+
+trait AssetsResourcesTest {
+  self: ServerTestBase[EndpointsTestApi] =>
+
+  def assetsResources(pathPrefix: Option[String]): serverApi.AssetRequest => serverApi.AssetResponse
+  def request2response = assetsResources(Some("/assets"))
+
+  "assetsResources" should {
+
+    "respond Found for existing asset" in {
+      val request = serverApi.AssetRequest(
+        serverApi.AssetPath(Seq(), None, "asset1.txt"),
+        false,
+        None
+      )
+
+      val response = request2response(request)
+      response shouldBe a[serverApi.AssetResponse.Found]
+    }
+
+    "respond NotFound for non-existing asset" in {
+      val request = serverApi.AssetRequest(
+        serverApi.AssetPath(Seq(), None, "asset-non-existing.txt"),
+        false,
+        None
+      )
+
+      val response = request2response(request)
+      response should be theSameInstanceAs serverApi.AssetResponse.NotFound
+    }
+
+    "evaluate If-Modified-Since header (rfc7232)" in {
+      val request = serverApi.AssetRequest(
+        serverApi.AssetPath(Seq(), None, "asset1.txt"),
+        false,
+        Some(HttpDate.MaxValue)
+      )
+
+      val response = request2response(request)
+
+      response should have(
+        Symbol("isExpired")(false)
+      )
+    }
+  }
+
+}

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/AssetsResourcesTest.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/AssetsResourcesTest.scala
@@ -13,7 +13,7 @@ trait AssetsResourcesTest {
 
     "respond Found for existing asset" in {
       val request = serverApi.AssetRequest(
-        serverApi.AssetPath(Seq(), None, "asset1.txt"),
+        serverApi.AssetPath(Seq(), "asset1.txt"),
         false,
         None
       )
@@ -24,7 +24,7 @@ trait AssetsResourcesTest {
 
     "respond NotFound for non-existing asset" in {
       val request = serverApi.AssetRequest(
-        serverApi.AssetPath(Seq(), None, "asset-non-existing.txt"),
+        serverApi.AssetPath(Seq(), "asset-non-existing.txt"),
         false,
         None
       )
@@ -35,7 +35,7 @@ trait AssetsResourcesTest {
 
     "evaluate If-Modified-Since header (rfc7232)" in {
       val request = serverApi.AssetRequest(
-        serverApi.AssetPath(Seq(), None, "asset1.txt"),
+        serverApi.AssetPath(Seq(), "asset1.txt"),
         false,
         Some(HttpDate.MaxValue)
       )

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
@@ -3,9 +3,8 @@ package endpoints4s.http4s.server
 import cats.effect.IO
 import endpoints4s.algebra
 
-class EndpointsTestApi(
-    val digests: Map[String, String]
-) extends Endpoints[IO]
+class EndpointsTestApi
+    extends Endpoints[IO]
     with BasicAuthentication
     with JsonEntitiesFromSchemas
     with Assets

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
@@ -3,10 +3,13 @@ package endpoints4s.http4s.server
 import cats.effect.IO
 import endpoints4s.algebra
 
-class EndpointsTestApi
-    extends Endpoints[IO]
+class EndpointsTestApi(
+    val digests: Map[String, String]
+) extends Endpoints[IO]
     with BasicAuthentication
     with JsonEntitiesFromSchemas
+    with Assets
+    with algebra.AssetsTestApi
     with algebra.EndpointsTestApi
     with algebra.BasicAuthenticationTestApi
     with algebra.JsonEntitiesFromSchemasTestApi

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
@@ -17,4 +17,10 @@ class EndpointsTestApi(
     with algebra.SumTypedEntitiesTestApi {
 
   implicit def userCodec = userJsonSchema
+
+  type AssetContent = fs2.Stream[Effect, Byte]
+
+  def noopAssetContent: fs2.Stream[Effect, Byte] = fs2.Stream.empty
+
+  def notFoundAssetResponse: AssetResponse = AssetResponse.NotFound
 }

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/ServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/ServerInterpreterTest.scala
@@ -33,7 +33,7 @@ class ServerInterpreterTest
   implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
   implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
-  val serverApi = new EndpointsTestApi(Map.empty)
+  val serverApi = new EndpointsTestApi
 
   def decodeUrl[A](url: serverApi.Url[A])(rawValue: String): DecodedUrl[A] = {
     val uri =

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/Assets.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/Assets.scala
@@ -45,7 +45,7 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors with StatusCo
       )
     endpoint(
       DocumentedRequest(Get, url, emptyRequestHeaders, None, emptyRequest),
-      response(OK) :: response(NotFound) :: response(NotModified) :: Nil
+      response(OK) :: response(NotModified) :: response(NotFound) :: Nil
     )
   }
 

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/Assets.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/Assets.scala
@@ -35,23 +35,19 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors with StatusCo
       url: Url[AssetPath],
       docs: Documentation,
       notFoundDocs: Documentation
-  ): Endpoint[AssetRequest, AssetResponse] =
-    endpoint(
-      DocumentedRequest(Get, url, emptyRequestHeaders, None, emptyRequest),
+  ): Endpoint[AssetRequest, AssetResponse] = {
+    def response(statusCode: StatusCode) =
       DocumentedResponse(
-        OK,
+        statusCode,
         docs.getOrElse(""),
         emptyResponseHeaders,
         Map.empty
-      ) ::
-        DocumentedResponse(
-          NotFound,
-          notFoundDocs.getOrElse(""),
-          emptyResponseHeaders,
-          Map.empty
-        ) ::
-        Nil
+      )
+    endpoint(
+      DocumentedRequest(Get, url, emptyRequestHeaders, None, emptyRequest),
+      response(OK) :: response(NotFound) :: response(NotModified) :: Nil
     )
+  }
 
   def digests: Map[String, String] = Map.empty
 

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/StatusCodes.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/StatusCodes.scala
@@ -21,7 +21,7 @@ trait StatusCodes extends endpoints4s.algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
-  def NotModified = 304
+  override def NotModified = 304
 
   def BadRequest = 400
   def Unauthorized = 401

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/StatusCodes.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/StatusCodes.scala
@@ -21,6 +21,8 @@ trait StatusCodes extends endpoints4s.algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
+  def NotModified = 304
+
   def BadRequest = 400
   def Unauthorized = 401
   override def PaymentRequired = 402

--- a/play/client/src/main/scala/endpoints4s/play/client/StatusCodes.scala
+++ b/play/client/src/main/scala/endpoints4s/play/client/StatusCodes.scala
@@ -20,7 +20,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
-  def NotModified = 304
+  override def NotModified = 304
 
   def BadRequest = 400
   def Unauthorized = 401

--- a/play/client/src/main/scala/endpoints4s/play/client/StatusCodes.scala
+++ b/play/client/src/main/scala/endpoints4s/play/client/StatusCodes.scala
@@ -20,6 +20,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
+  def NotModified = 304
+
   def BadRequest = 400
   def Unauthorized = 401
   override def PaymentRequired = 402

--- a/play/server/src/main/scala/endpoints4s/play/server/Assets.scala
+++ b/play/server/src/main/scala/endpoints4s/play/server/Assets.scala
@@ -142,7 +142,7 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
       invariantFunctorRequest
         .inmap( // TODO remove this boilerplate using play-products
           request(Get, url, headers = gzipSupport),
-          (t: (AssetPath, Boolean)) => AssetRequest(t._1, t._2),
+          AssetRequest.tupled,
           (assetRequest: AssetRequest) => (assetRequest.assetPath, assetRequest.isGzipSupported)
         )
 

--- a/play/server/src/main/scala/endpoints4s/play/server/Assets.scala
+++ b/play/server/src/main/scala/endpoints4s/play/server/Assets.scala
@@ -13,7 +13,7 @@ import play.mvc.Http.HeaderNames
   *
   * @group interpreters
   */
-trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
+trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
 
   /**
     * @param assetPath Path of the requested asset
@@ -100,29 +100,6 @@ trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
       contentType: Option[String],
       isGzipped: Boolean
   ) extends AssetResponse
-
-  def notFoundAssetResponse = AssetNotFound
-
-  type AssetContent = Source[ByteString, _]
-
-  def foundAssetResponse(
-      content: AssetContent,
-      contentLength: Long,
-      fileName: String,
-      isGzipped: Boolean,
-      isExpired: Boolean,
-      lastModifiedSeconds: Long
-  ) =
-    Found(
-      content,
-      Some(contentLength),
-      playComponents.fileMimeTypes
-        .forFileName(fileName)
-        .orElse(Some(ContentTypes.BINARY)),
-      isGzipped
-    )
-
-  override def noopAssetContent = Source.empty
 
   /**
     * Decodes and encodes an [[AssetPath]] into a URL path.
@@ -222,17 +199,17 @@ trait Assets extends algebra.ServerAssets with EndpointsWithCustomErrors {
         maybeAsset
           .map {
             case (stream, isGzipped) =>
-              foundAssetResponse(
-                content = StreamConverters.fromInputStream(() => stream),
-                contentLength = stream.available().toLong,
-                fileName = assetInfo.name,
-                isGzipped = isGzipped,
-                isExpired = true,
-                lastModifiedSeconds = 0
+              Found(
+                StreamConverters.fromInputStream(() => stream),
+                Some(stream.available().toLong),
+                playComponents.fileMimeTypes
+                  .forFileName(assetInfo.name)
+                  .orElse(Some(ContentTypes.BINARY)),
+                isGzipped
               )
           }
-          .getOrElse(notFoundAssetResponse)
-      } else notFoundAssetResponse
+          .getOrElse(AssetNotFound)
+      } else AssetNotFound
     }
 
 }

--- a/play/server/src/main/scala/endpoints4s/play/server/StatusCodes.scala
+++ b/play/server/src/main/scala/endpoints4s/play/server/StatusCodes.scala
@@ -21,6 +21,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = Results.Status(208)
   override def IMUsed = Results.Status(226)
 
+  def NotModified = Results.Status(304)
+
   def BadRequest = Results.BadRequest
   def Unauthorized = Results.Unauthorized
   override def PaymentRequired = Results.Status(402)

--- a/play/server/src/main/scala/endpoints4s/play/server/StatusCodes.scala
+++ b/play/server/src/main/scala/endpoints4s/play/server/StatusCodes.scala
@@ -21,7 +21,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = Results.Status(208)
   override def IMUsed = Results.Status(226)
 
-  def NotModified = Results.Status(304)
+  override def NotModified = Results.Status(304)
 
   def BadRequest = Results.BadRequest
   def Unauthorized = Results.Unauthorized

--- a/scalaj/client/src/main/scala/endpoints4s/scalaj/client/StatusCodes.scala
+++ b/scalaj/client/src/main/scala/endpoints4s/scalaj/client/StatusCodes.scala
@@ -20,7 +20,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
-  def NotModified = 304
+  override def NotModified = 304
 
   def BadRequest = 400
   def Unauthorized = 401

--- a/scalaj/client/src/main/scala/endpoints4s/scalaj/client/StatusCodes.scala
+++ b/scalaj/client/src/main/scala/endpoints4s/scalaj/client/StatusCodes.scala
@@ -20,6 +20,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
+  def NotModified = 304
+
   def BadRequest = 400
   def Unauthorized = 401
   override def PaymentRequired = 402

--- a/sttp/client/src/main/scala/endpoints4s/sttp/client/StatusCodes.scala
+++ b/sttp/client/src/main/scala/endpoints4s/sttp/client/StatusCodes.scala
@@ -20,7 +20,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
-  def NotModified = 304
+  override def NotModified = 304
 
   def BadRequest = 400
   def Unauthorized = 401

--- a/sttp/client/src/main/scala/endpoints4s/sttp/client/StatusCodes.scala
+++ b/sttp/client/src/main/scala/endpoints4s/sttp/client/StatusCodes.scala
@@ -20,6 +20,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
+  def NotModified = 304
+
   def BadRequest = 400
   def Unauthorized = 401
   override def PaymentRequired = 402

--- a/xhr/client/src/main/scala/endpoints4s/xhr/StatusCodes.scala
+++ b/xhr/client/src/main/scala/endpoints4s/xhr/StatusCodes.scala
@@ -22,6 +22,8 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
+  def NotModified = 304
+
   def BadRequest = 400
   def Unauthorized = 401
   override def PaymentRequired = 402

--- a/xhr/client/src/main/scala/endpoints4s/xhr/StatusCodes.scala
+++ b/xhr/client/src/main/scala/endpoints4s/xhr/StatusCodes.scala
@@ -22,7 +22,7 @@ trait StatusCodes extends algebra.StatusCodes {
   override def AlreadyReported = 208
   override def IMUsed = 226
 
-  def NotModified = 304
+  override def NotModified = 304
 
   def BadRequest = 400
   def Unauthorized = 401


### PR DESCRIPTION
This PR aims to add the missing `Assets` interpreter for Http4s :slightly_smiling_face:  . It is based on the Http4s StaticFile `fromResource` (https://github.com/http4s/http4s/blob/master/core/src/main/scala/org/http4s/StaticFile.scala#L34): any non trivial logic in this PR originates from there, as well as the existing Play Assets interpreter.

I noticed that while the Play Assets interpreter supports asset fingerprinting, there is no way to opt out of it: digests must be provided otherwise assets cannot be retrieved. I implemented digests to be optional for the Http4s interpreter, but I can revert this if you think differently. Also note that the Http4s `fromResource` implements caching via If-Modified-Since header, which is followed in this PR.

I used the interpreter successfully in a personal project, but wanted to add tests as well. I noticed that tests for Assets are missing altogether (including for Play Assets)? It is possible to add these tests, but it would require some refactoring (to `ServerInterpreterTest` and other components). If wanted I could try and do this in this PR, though maybe with some directions from you if possible :slightly_smiling_face:.