### PR TITLE
Streamline the way servers decode request headers

### DIFF
--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -35,6 +35,7 @@ val `akka-http-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "akka-http-server",
+      version := "2.0.0",
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-http" % akkaHttpVersion).withDottyCompat(scalaVersion.value),
         ("com.typesafe.akka" %% "akka-stream" % akkaActorVersion).withDottyCompat(scalaVersion.value),

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Endpoints.scala
@@ -246,7 +246,7 @@ trait EndpointsWithCustomErrors
     val headersDirective: Directive1[C] =
       directive1InvFunctor.xmapPartial[Validated[C], C](
         Directives.extractRequest.map(headers.decode),
-        validatedC => validatedC,
+        identity,
         c => Valid(c)
       )
     val matchDirective = methodDirective & url.directive & headersDirective

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
@@ -460,7 +460,7 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
       }
     }
 
-    "reject request with missing headers" in {
+    "reject requests with missing headers" in {
       serveEndpoint(joinedHeadersEndpoint, "success") { port =>
         val noHeadersRequest =
           HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
@@ -460,8 +460,8 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
       }
     }
 
-    "reject requests with missing headers" in {
-      serveEndpoint(joinedHeadersEndpoint, "success") { port =>
+    "reject requests with two missing headers" in {
+      serveEndpoint(joinedHeadersEndpoint, "ignored") { port =>
         val noHeadersRequest =
           HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")
         whenReady(sendAndDecodeEntityAsText(noHeadersRequest)) {
@@ -469,6 +469,12 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
             assert(response.status == StatusCodes.BadRequest)
             assert(entity == """["Missing header A","Missing header B"]""")
         }
+        ()
+      }
+    }
+
+    "reject requests with one missing header" in {
+      serveEndpoint(joinedHeadersEndpoint, "ignored") { port =>
         val oneHeader =
           HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")
             .withHeaders(RawHeader("A", "foo"))
@@ -477,6 +483,12 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
             assert(response.status == StatusCodes.BadRequest)
             assert(entity == """["Missing header B"]""")
         }
+        ()
+      }
+    }
+
+    "accept requests with the required headers" in {
+      serveEndpoint(joinedHeadersEndpoint, "success") { port =>
         val twoHeaders =
           HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")
             .withHeaders(RawHeader("A", "foo"), RawHeader("B", "foo"))

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
@@ -471,7 +471,7 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
         }
         val oneHeader =
           HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")
-              .withHeaders(RawHeader("A", "foo"))
+            .withHeaders(RawHeader("A", "foo"))
         whenReady(sendAndDecodeEntityAsText(oneHeader)) {
           case (response, entity) =>
             assert(response.status == StatusCodes.BadRequest)
@@ -479,7 +479,7 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
         }
         val twoHeaders =
           HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")
-              .withHeaders(RawHeader("A", "foo"), RawHeader("B", "foo"))
+            .withHeaders(RawHeader("A", "foo"), RawHeader("B", "foo"))
         whenReady(sendAndDecodeEntityAsText(twoHeaders)) {
           case (response, entity) =>
             assert(response.status == StatusCodes.OK)

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -360,8 +360,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
       def product[A, B](fa: RequestHeaders[A], fb: RequestHeaders[B])(implicit
           tupler: Tupler[A, B]
       ): RequestHeaders[tupler.Out] =
-        headers =>
-          fa(headers).zip(fb(headers))
+        headers => fa(headers).zip(fb(headers))
     }
 
   /**

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -361,8 +361,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
           tupler: Tupler[A, B]
       ): RequestHeaders[tupler.Out] =
         headers =>
-          fa(headers)
-            .flatMap(a => fb(headers).map(b => tupler(a, b)))
+          fa(headers).zip(fb(headers))
     }
 
   /**


### PR DESCRIPTION
The way server interpreters handle request headers was not consistent between interpreters.

This PR makes sure that all the servers:

- reject request whose headers are missing with a standard Bad Request response,
- return all the errors related to request headers validation (not just the first one).