### PR TITLE
change http4s server to support effectful errorhandling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ node_modules/
 .vscode/
 
 project/metals.sbt
+
+#direnv, niv and lorri
+.envrc
+shell.nix
+nix

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -108,15 +108,15 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
                   implementation(a)
                     .map(response)
                     .recoverWith {
-                      case NonFatal(t) => handleServerErrorEffect(t)
+                      case NonFatal(t) => handleServerError(t)
                     }
                 } catch {
-                  case NonFatal(t) => handleServerErrorEffect(t)
+                  case NonFatal(t) => handleServerError(t)
                 }
               case Left(errorResponse) => errorResponse.pure[Effect]
             })
         } catch {
-          case NonFatal(t) => Some(handleServerErrorEffect(t))
+          case NonFatal(t) => Some(handleServerError(t))
         }
       }
       Function.unlift(handler)
@@ -263,7 +263,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
               case Right(a) =>
                 f(a) match {
                   case Valid(value)     => Effect.pure(value.asRight)
-                  case invalid: Invalid => handleClientErrorsEffect(invalid).map(_.asLeft)
+                  case invalid: Invalid => handleClientErrors(invalid).map(_.asLeft)
                 }
             })
         )
@@ -328,7 +328,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
           .map[Validated[(U, H)]](_.zip(headers(http4sRequest.headers)))
           .map {
             case Valid(urlAndHeaders) => entity(urlAndHeaders)(http4sRequest)
-            case inv: Invalid         => handleClientErrorsEffect(inv).map(_.asLeft)
+            case inv: Invalid         => handleClientErrors(inv).map(_.asLeft)
           }
       } else None
     }
@@ -347,7 +347,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
             case Right(from) =>
               map(from) match {
                 case Valid(response)  => Effect.pure(response.asRight)
-                case invalid: Invalid => handleClientErrorsEffect(invalid).map(_.asLeft)
+                case invalid: Invalid => handleClientErrors(invalid).map(_.asLeft)
               }
           }
 
@@ -380,7 +380,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleClientErrorsEffect(invalid: Invalid): Effect[http4s.Response[Effect]] =
+  def handleClientErrors(invalid: Invalid): Effect[http4s.Response[Effect]] =
     Effect.pure(clientErrorsResponse(invalidToClientErrors(invalid)))
 
   /**
@@ -392,7 +392,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleServerErrorEffect(throwable: Throwable): Effect[http4s.Response[Effect]] =
+  def handleServerError(throwable: Throwable): Effect[http4s.Response[Effect]] =
     Effect.pure(serverErrorResponse(throwableToServerError(throwable)))
 
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -380,11 +380,8 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleClientErrors(invalid: Invalid): http4s.Response[Effect] =
-    clientErrorsResponse(invalidToClientErrors(invalid))
-
   def handleClientErrorsEffect(invalid: Invalid): Effect[http4s.Response[Effect]] =
-    Effect.pure(handleClientErrors(invalid))
+    Effect.pure(clientErrorsResponse(invalidToClientErrors(invalid)))
 
   /**
     * This method is called by ''endpoints'' when an exception is thrown during
@@ -395,10 +392,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleServerError(throwable: Throwable): http4s.Response[Effect] =
-    serverErrorResponse(throwableToServerError(throwable))
-
   def handleServerErrorEffect(throwable: Throwable): Effect[http4s.Response[Effect]] =
-    Effect.pure(handleServerError(throwable))
+    Effect.pure(serverErrorResponse(throwableToServerError(throwable)))
 
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -28,11 +28,11 @@ trait JsonEntitiesFromCodecs extends algebra.JsonEntitiesFromCodecs with Endpoin
         .decode(req, strict = true)
         .leftWiden[Throwable]
         .rethrowT
-        .map { value =>
+        .flatMap { value =>
           stringCodec(codec)
             .decode(value) match {
-            case Valid(a)     => Right(a)
-            case inv: Invalid => Left(handleClientErrors(inv))
+            case Valid(a)     => Effect.pure(Right(a))
+            case inv: Invalid => handleClientErrorsEffect(inv).map(Left.apply)
           }
         }
 

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -32,7 +32,7 @@ trait JsonEntitiesFromCodecs extends algebra.JsonEntitiesFromCodecs with Endpoin
           stringCodec(codec)
             .decode(value) match {
             case Valid(a)     => Effect.pure(Right(a))
-            case inv: Invalid => handleClientErrorsEffect(inv).map(Left.apply)
+            case inv: Invalid => handleClientErrors(inv).map(Left.apply)
           }
         }
 


### PR DESCRIPTION
I am not entirely sure if the way I handled `handleXError` with `handleXErrorEffect` is very smart. The idea was to retain compatibility.