### PR TITLE
Bump the major version number of the http4s-server module

### DIFF
--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -12,7 +12,7 @@ val `http4s-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-server",
-      version := "2.0.0",
+      version := "3.0.0",
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-core" % http4sVersion).withDottyCompat(scalaVersion.value),
         ("org.http4s" %% "http4s-dsl" % http4sVersion).withDottyCompat(scalaVersion.value),


### PR DESCRIPTION
We have changed the signature of `handleClientErrors` and `handleServerError` in a backward binary incompatible way.