### PR TITLE
Make Http header extraction case insensitive in http4s server interpreter

### DIFF
--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/EndpointsTestSuite.scala
@@ -488,6 +488,19 @@ trait EndpointsTestSuite[T <: endpoints4s.algebra.EndpointsTestApi] extends Serv
       }
     }
 
+    "accept requests with the required case insensitive headers" in {
+      serveEndpoint(joinedHeadersEndpoint, "success") { port =>
+        val twoHeaders =
+          HttpRequest(uri = s"http://localhost:$port/joinedHeadersEndpoint")
+            .withHeaders(RawHeader("a", "foo"), RawHeader("b", "foo"))
+        whenReady(sendAndDecodeEntityAsText(twoHeaders)) { case (response, entity) =>
+          assert(response.status == StatusCodes.OK)
+          assert(entity == "success")
+        }
+        ()
+      }
+    }
+
     "decode transformed request headers" in {
       serveEndpoint(xmapHeadersEndpoint, "ignored") { port =>
         val validRequest =

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -16,6 +16,7 @@ import org.http4s
 import org.http4s.{EntityEncoder, EntityDecoder, Header, Headers}
 
 import scala.util.control.NonFatal
+import org.http4s.util.CaseInsensitiveString
 
 /**
   * Interpreter for [[algebra.Endpoints]] based on http4s. It uses [[algebra.BuiltInErrors]]
@@ -137,9 +138,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
 
   def requestHeader(name: String, docs: Documentation): RequestHeaders[String] =
     headers =>
-      headers.collectFirst {
-        case h if h.name.value == name => h.value
-      } match {
+      headers.get(CaseInsensitiveString(name)).map(_.value) match {
         case Some(value) => Valid(value)
         case None        => Invalid(s"Missing header $name")
       }
@@ -148,10 +147,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
       name: String,
       docs: Documentation
   ): RequestHeaders[Option[String]] =
-    headers =>
-      Valid(headers.collectFirst {
-        case h if h.name.value == name => h.value
-      })
+    headers => Valid(headers.get(CaseInsensitiveString(name)).map(_.value))
 
   // RESPONSES
   implicit lazy val responseInvariantFunctor: endpoints4s.InvariantFunctor[Response] =


### PR DESCRIPTION
Fixes #638 