### PR TITLE
Provide `JsonSchema[Set[?]]` instance out of the box

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
@@ -348,7 +348,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
   implicit def byteJsonSchema: JsonSchema[Byte] =
     JsonSchema(implicitly, implicitly)
 
-  implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+  implicit def arrayJsonSchema[C[X] <: Iterable[X], A](implicit
       jsonSchema: JsonSchema[A],
       factory: Factory[A, C[A]]
   ): JsonSchema[C[A]] =

--- a/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
@@ -239,7 +239,7 @@ class JsonSchemasTest extends AnyFreeSpec {
 
     lazy val byteJsonSchema: String = "byte"
 
-    def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+    def arrayJsonSchema[C[X] <: Iterable[X], A](implicit
         jsonSchema: String,
         factory: Factory[A, C[A]]
     ): String = s"[$jsonSchema]"

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
@@ -230,7 +230,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
   implicit def byteJsonSchema: JsonSchema[Byte] =
     JsonSchema(implicitly, implicitly)
 
-  implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+  implicit def arrayJsonSchema[C[X] <: Iterable[X], A](implicit
       jsonSchema: JsonSchema[A],
       factory: Factory[A, C[A]]
   ): JsonSchema[C[A]] =

--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -743,7 +743,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
   /** A JSON schema for sequences
     * @group operations
     */
-  implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+  implicit def arrayJsonSchema[C[X] <: Iterable[X], A](implicit
       jsonSchema: JsonSchema[A],
       factory: Factory[A, C[A]]
   ): JsonSchema[C[A]]

--- a/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasOptionalFieldsTest.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasOptionalFieldsTest.scala
@@ -159,6 +159,10 @@ trait JsonSchemasOptionalFieldsTest extends AnyFreeSpec with JsonSchemasFixtures
     )
   }
 
+  "Set" in {
+    checkRoundTrip[Set[Int]](implicitly, Json.arr(Json.num(1)), Set(1))
+  }
+
   def checkRoundTrip[A](schema: JsonSchema[A], json: Json.Json, decoded: A) =
     decodeJson(schema, json) match {
       case Valid(a) =>

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -578,7 +578,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   lazy val byteJsonSchema: JsonSchema[Byte] =
     new JsonSchema(ujsonSchemas.byteJsonSchema, Primitive("integer"))
 
-  def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+  def arrayJsonSchema[C[X] <: Iterable[X], A](implicit
       jsonSchema: JsonSchema[A],
       factory: Factory[A, C[A]]
   ): JsonSchema[C[A]] =

--- a/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
@@ -376,7 +376,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
       val encoder = b => ujson.Num(b.toDouble)
     }
 
-  implicit def arrayJsonSchema[C[X] <: Seq[X], A](implicit
+  implicit def arrayJsonSchema[C[X] <: Iterable[X], A](implicit
       jsonSchema: JsonSchema[A],
       factory: Factory[A, C[A]]
   ): JsonSchema[C[A]] =
@@ -396,7 +396,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
             .map(_.result())
         case json => Invalid(s"Invalid JSON array: $json")
       }
-      val encoder = as => ujson.Arr(as.map(jsonSchema.codec.encode): _*)
+      val encoder = as => ujson.Arr.from(as.map(jsonSchema.codec.encode))
     }
 
   implicit def mapJsonSchema[A](implicit


### PR DESCRIPTION
We achieve this by relaxing the constraint on the type signature of the existing method `arrayJsonSchema`. It now applies to any `Iterable` collection instead of the more specific type `Seq`.

Fixes #682