### PR TITLE
Compress the responses sent by the server, if the client supports it

### DIFF
--- a/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/ServerInterpreterTest.scala
+++ b/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/ServerInterpreterTest.scala
@@ -25,6 +25,7 @@ class ServerInterpreterTest
     with algebra.server.ChunkedJsonEntitiesTestSuite[EndpointsCodecsTestApi]
     with algebra.server.TextEntitiesTestSuite[EndpointsCodecsTestApi]
     with algebra.server.SumTypedEntitiesTestSuite[EndpointsCodecsTestApi]
+    with algebra.server.ContentEncodingTestSuite[EndpointsCodecsTestApi]
     with ScalatestRouteTest {
 
   val serverApi = new EndpointsCodecsTestApi

--- a/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ContentEncodingTestSuite.scala
+++ b/algebras/algebra/src/test/scala/endpoints4s/algebra/server/ContentEncodingTestSuite.scala
@@ -1,0 +1,48 @@
+package endpoints4s.algebra.server
+
+import akka.http.scaladsl.coding.Coders.Gzip
+import akka.http.scaladsl.model.headers.HttpEncodings.gzip
+import akka.http.scaladsl.model.headers.{HttpEncoding, `Accept-Encoding`, `Content-Encoding`}
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
+import endpoints4s.algebra.EndpointsTestApi
+
+trait ContentEncodingTestSuite[T <: EndpointsTestApi] extends EndpointsTestSuite[T] {
+
+  "ContentEncoding" should {
+    "be set according to request’s Accept-Encoding header" in {
+      serveEndpoint(serverApi.smokeEndpoint, "response") { port =>
+        val basicRequest =
+          HttpRequest(uri = s"http://localhost:$port/user/abcd/description?name=a&age=0")
+
+        // No Accept-Encoding: response is not encoded
+        whenReady(send(basicRequest)) { case (response, entity) =>
+          response.status shouldBe StatusCodes.OK
+          assert(response.headers[`Content-Encoding`].isEmpty)
+          entity.utf8String shouldBe "response"
+        }
+
+        val acceptGzipRequest = basicRequest.withHeaders(`Accept-Encoding`(gzip))
+        // Accept gzip: response is compressed
+        whenReady(send(acceptGzipRequest)) { case (response, entity) =>
+          response.status shouldBe StatusCodes.OK
+          assert(response.headers[`Content-Encoding`].contains(`Content-Encoding`(gzip)))
+          whenReady(Gzip.decode(entity)) { decodedEntity =>
+            decodedEntity.utf8String shouldBe "response"
+          }
+        }
+
+        val acceptCustomEncodingRequest =
+          basicRequest.withHeaders(`Accept-Encoding`(HttpEncoding.custom("dummy")))
+        // Custom Accept-Encoding: no error, response is not encoded.
+        whenReady(send(acceptCustomEncodingRequest)) { case (response, entity) =>
+          response.status shouldBe StatusCodes.OK
+          assert(response.headers[`Content-Encoding`].isEmpty)
+          assert(entity.utf8String == "response")
+        }
+
+        ()
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Leverage the `Accept-Encoding` header in the akka-http server interpreter to automatically compress responses sent by the server, if this is supported by the client.

I expect this change to be just an “implementation detail” so, it should not change anything to existing users of the akka-http-server interpreter, except that responses are now compressed if this is supported by the client. Therefore, there is no way to configure or disable this behavior.

Please let me know if you think this should be opt-in.

The optimization is implemented for the akka-http-server interpreter only. Users of the http4s-server interpreter can just use the `Gzip` middleware on the service produced by endpoints4s (so, I would say that there is nothing to do on the endpoints4s side…).