### PR TITLE
Add a method that returns an `Uri` to the class `Endpoint` in the akka-http-server interpreter

### DIFF
--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Endpoints.scala
@@ -2,7 +2,7 @@ package endpoints4s.akkahttp.server
 
 import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller, ToResponseMarshaller}
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpEntity, HttpHeader, HttpRequest, MediaTypes}
+import akka.http.scaladsl.model.{HttpEntity, HttpHeader, HttpRequest, MediaTypes, Uri}
 import akka.http.scaladsl.server.{Directive1, Directives, ExceptionHandler, Route, StandardRoute}
 import akka.http.scaladsl.unmarshalling._
 import endpoints4s.algebra.Documentation
@@ -41,7 +41,14 @@ trait EndpointsWithCustomErrors
     def decode(httpRequest: HttpRequest): Validated[A]
   }
 
-  type Request[A] = Directive1[A]
+  trait Request[A] {
+
+    /** A directive that extracts an `A` from an incoming request */
+    def directive: Directive1[A]
+
+    /** The URI of a request carrying the given `a` parameter */
+    def uri(a: A): Uri
+  }
 
   type RequestEntity[A] = Directive1[A]
 
@@ -74,20 +81,35 @@ trait EndpointsWithCustomErrors
     ExceptionHandler { case NonFatal(t) => handleServerError(t) }
 
   case class Endpoint[A, B](request: Request[A], response: Response[B]) {
+
+    /** @return An Akka HTTP `Route` for this endpoint
+      * @param implementation Function that transforms the `A` value carried in
+      *                       the request into a `B` value to send in the response.
+      */
     def implementedBy(implementation: A => B): Route =
       Directives.handleExceptions(endpointsExceptionHandler) {
-        request { arguments => response(implementation(arguments)) }
+        request.directive { arguments => response(implementation(arguments)) }
       }
 
+    /** @return An Akka HTTP `Route` for this endpoint
+      * @param implementation Asynchronous function that transforms the `A` value
+      *                       carried in the request into a `B` value to send in
+      *                       the response.
+      */
     def implementedByAsync(implementation: A => Future[B]): Route =
       Directives.handleExceptions(endpointsExceptionHandler) {
-        request { arguments =>
+        request.directive { arguments =>
           Directives.onComplete(implementation(arguments)) {
             case Success(result) => response(result)
             case Failure(ex)     => throw ex
           }
         }
       }
+
+    /** @return The `Uri` of this endpoint, for a request carrying the
+      *         given `a` value.
+      */
+    def uri(a: A): Uri = request.uri(a)
   }
 
   /* ************************
@@ -95,7 +117,13 @@ trait EndpointsWithCustomErrors
   ************************* */
 
   implicit def requestPartialInvariantFunctor: PartialInvariantFunctor[Request] =
-    directive1InvFunctor
+    new PartialInvariantFunctor[Request] {
+      def xmapPartial[A, B](fa: Request[A], f: A => Validated[B], g: B => A): Request[B] =
+        new Request[B] {
+          val directive: Directive1[B] = directive1InvFunctor.xmapPartial(fa.directive, f, g)
+          def uri(b: B): Uri = fa.uri(g(b))
+        }
+    }
 
   def emptyRequest: RequestEntity[Unit] = convToDirective1(Directives.pass)
 
@@ -239,17 +267,24 @@ trait EndpointsWithCustomErrors
   )(implicit
       tuplerAB: Tupler.Aux[A, B, AB],
       tuplerABC: Tupler.Aux[AB, C, Out]
-  ): Request[Out] = {
-    val methodDirective = convToDirective1(Directives.method(method))
-    val headersDirective: Directive1[C] =
-      directive1InvFunctor.xmapPartial[Validated[C], C](
-        Directives.extractRequest.map(headers.decode),
-        identity,
-        c => Valid(c)
-      )
-    val matchDirective = methodDirective & url.directive & headersDirective
-    matchDirective.tflatMap { case (_, a, c) =>
-      entity.map(b => tuplerABC(tuplerAB(a, b), c))
+  ): Request[Out] = new Request[Out] {
+    val directive = {
+      val methodDirective = convToDirective1(Directives.method(method))
+      val headersDirective: Directive1[C] =
+        directive1InvFunctor.xmapPartial[Validated[C], C](
+          Directives.extractRequest.map(headers.decode),
+          identity,
+          c => Valid(c)
+        )
+      val matchDirective = methodDirective & url.directive & headersDirective
+      matchDirective.tflatMap { case (_, a, c) =>
+        entity.map(b => tuplerABC(tuplerAB(a, b), c))
+      }
+    }
+    def uri(out: Out): Uri = {
+      val (ab, _) = tuplerABC.unapply(out)
+      val (a, _) = tuplerAB.unapply(ab)
+      url.uri(a)
     }
   }
 

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/MuxEndpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/MuxEndpoints.scala
@@ -34,7 +34,7 @@ trait MuxEndpoints extends algebra.MuxEndpoints with EndpointsWithCustomErrors {
         encoder: Encoder[Resp, Transport]
     ): Route =
       Directives.handleExceptions(endpointsExceptionHandler) {
-        request { request =>
+        request.directive { request =>
           decoder.decode(request) match {
             case inv: Invalid => handleClientErrors(inv)
             case Valid(req) =>

--- a/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/RequestUriTest.scala
+++ b/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/RequestUriTest.scala
@@ -1,0 +1,30 @@
+package endpoints4s.akkahttp.server
+
+import endpoints4s.algebra
+import org.scalatest.wordspec.AnyWordSpec
+
+class RequestUriTest extends AnyWordSpec {
+
+  trait Fixtures extends algebra.Endpoints {
+    val p1 = path / "a" / "b/c" / segment[String]()
+    val p2 = path / segment[String]() / segment[String]() / remainingSegments()
+    val p3 = path / segment[String]() /? (qs[String]("q") & qs[Option[String]]("r") & qs[List[String]]("s"))
+    val p4 = path / "a" /? qs[Option[Int]]("x")
+    val e  = endpoint(get(p4), ok(textResponse))
+  }
+
+  object Fixtures extends Fixtures with Endpoints
+
+  "akka-http-server request interpreter" should {
+    "properly encode URIs" in {
+      import Fixtures.{ p1, p2, p3, p4, e }
+      assert(p1.uri("d/e").toString == "/a/b%2Fc/d%2Fe")
+      assert(p2.uri(("a b", "c/d", "e/f")).toString == "/a%20b/c%2Fd/e/f")
+      assert(p2.uri(("a b", "c/d", "")).toString == "/a%20b/c%2Fd/")
+      assert(p3.uri(("a b", ("c d", Some("e f"), List("g h", "i j")))).toString == "/a%20b?q=c+d&r=e+f&s=g+h&s=i+j")
+      assert(p4.uri(None).toString == "/a")
+      assert(e.uri(Some(42)).toString == "/a?x=42")
+    }
+  }
+
+}


### PR DESCRIPTION
It is useful to produce links, for instance to reference endpoints from other endpoints (e.g., in a HATEOAS API). This was supported from the beginning by the play-server interpreter. We now also support it in the akka-http-server interpreter.