### PR TITLE
Document the version of Akka and Akka HTTP used by the akka-http-server interpreter

### DIFF
--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -98,11 +98,13 @@ val manual =
           .withCustomStylesheet("snippets.css")
       },
       paradoxProperties ++= Map(
-        "version"           -> version.value,
+        "version"                  -> version.value,
         "akka-http-server-version" -> (`akka-http-server` / version).value,
-        "xhr-client-version" -> (`xhr-client` / version).value,
-        "scaladoc.base_url" -> s".../${(packageDoc / siteSubdirName).value}",
-        "github.base_url"   -> s"${(ThisBuild / sonatypeProjectHosting).value.get.scmInfo.browseUrl}/blob/v${version.value}"
+        "xhr-client-version"       -> (`xhr-client` / version).value,
+        "akka-version"             -> akkaActorVersion,
+        "akka-http-version"        -> akkaHttpVersion,
+        "scaladoc.base_url"        -> s".../${(packageDoc / siteSubdirName).value}",
+        "github.base_url"          -> s"${(ThisBuild / sonatypeProjectHosting).value.get.scmInfo.browseUrl}/blob/v${version.value}"
       ),
       paradoxDirectives += ((_: Writer.Context) => org.endpoints4s.paradox.coordinates.CoordinatesDirective),
       packageDoc / siteSubdirName := "api",

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -99,7 +99,7 @@ val manual =
       },
       paradoxProperties ++= Map(
         "version"           -> version.value,
-        "akka-http-version" -> (`akka-http-server` / version).value,
+        "akka-http-server-version" -> (`akka-http-server` / version).value,
         "xhr-client-version" -> (`xhr-client` / version).value,
         "scaladoc.base_url" -> s".../${(packageDoc / siteSubdirName).value}",
         "github.base_url"   -> s"${(ThisBuild / sonatypeProjectHosting).value.get.scmInfo.browseUrl}/blob/v${version.value}"

--- a/documentation/manual/src/main/paradox/interpreters/akka-http.md
+++ b/documentation/manual/src/main/paradox/interpreters/akka-http.md
@@ -43,6 +43,21 @@ It can be invoked as follows:
 
 @scaladoc[API documentation](endpoints4s.akkahttp.server.index)
 
+@@@ warning
+
+As explained in the section
+[Mixed versioning is not allowed](https://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed)
+in the Akka documentation, you have to make sure that all the
+Akka modules of your application depend on the same version of
+Akka, and that all the Akka HTTP modules of your application depend
+of the same version of Akka HTTP.
+
+For your information, the `akka-http-server` module of endpoints4s
+depends on Akka @var[akka-version] and Akka HTTP
+@var[akka-http-version].
+
+@@@
+
 ### `endpoints4s.akkahttp.server.Endpoints`
 
 The `Endpoints` interpreter fixes the `Endpoint[A, B]` type to something that,

--- a/documentation/manual/src/main/paradox/quick-start.md
+++ b/documentation/manual/src/main/paradox/quick-start.md
@@ -51,7 +51,7 @@ val client =
 val server =
   project.settings(
     libraryDependencies ++= Seq(
-      "org.endpoints4s" %% "akka-http-server" % "$akka-http-version$",
+      "org.endpoints4s" %% "akka-http-server" % "$akka-http-server-version$",
       "org.scala-stm" %% "scala-stm" % "0.8"
     )
   ).dependsOn(sharedJVM)


### PR DESCRIPTION
Since Akka and Akka HTTP don’t support “mixed versioning”, we include in the documentation the versions of Akka and Akka HTTP that endpoints4s depends on:

![Screenshot from 2021-01-28 10-56-33](https://user-images.githubusercontent.com/332812/106121466-e2cbfb00-6157-11eb-9d87-f64d6a32c8c6.png)
