### PR TITLE
Add request to client errors

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,3 @@
 -Xms2048M
 -Xmx4G
 -Xss6M
--XX:+CMSClassUnloadingEnabled

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -12,8 +12,8 @@ val `http4s-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-server",
-      version := "5.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      version := "6.0.0",
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-core" % http4sVersion).withDottyCompat(scalaVersion.value),
         ("org.http4s" %% "http4s-dsl" % http4sVersion).withDottyCompat(scalaVersion.value),

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -256,7 +256,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
               case Right(a) =>
                 f(a) match {
                   case Valid(value)     => Effect.pure(value.asRight)
-                  case invalid: Invalid => handleClientErrors(invalid).map(_.asLeft)
+                  case invalid: Invalid => handleClientErrors(http4sRequest, invalid).map(_.asLeft)
                 }
             })
         )
@@ -320,7 +320,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
           .map[Validated[(U, H)]](_.zip(headers(http4sRequest.headers)))
           .map {
             case Valid(urlAndHeaders) => entity(urlAndHeaders)(http4sRequest)
-            case inv: Invalid         => handleClientErrors(inv).map(_.asLeft)
+            case inv: Invalid         => handleClientErrors(http4sRequest, inv).map(_.asLeft)
           }
       } else None
     }
@@ -339,7 +339,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
             case Right(from) =>
               map(from) match {
                 case Valid(response)  => Effect.pure(response.asRight)
-                case invalid: Invalid => handleClientErrors(invalid).map(_.asLeft)
+                case invalid: Invalid => handleClientErrors(body, invalid).map(_.asLeft)
               }
           }
 
@@ -371,7 +371,7 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleClientErrors(invalid: Invalid): Effect[http4s.Response[Effect]] =
+  def handleClientErrors(request: http4s.Request[Effect], invalid: Invalid): Effect[http4s.Response[Effect]] =
     Effect.pure(clientErrorsResponse(invalidToClientErrors(invalid)))
 
   /** This method is called by ''endpoints'' when an exception is thrown during

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -107,15 +107,15 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
                   implementation(a)
                     .map(response)
                     .recoverWith { case NonFatal(t) =>
-                      handleServerError(t)
+                      handleServerError(http4sRequest, t)
                     }
                 } catch {
-                  case NonFatal(t) => handleServerError(t)
+                  case NonFatal(t) => handleServerError(http4sRequest, t)
                 }
               case Left(errorResponse) => errorResponse.pure[Effect]
             })
         } catch {
-          case NonFatal(t) => Some(handleServerError(t))
+          case NonFatal(t) => Some(handleServerError(http4sRequest, t))
         }
       }
       Function.unlift(handler)
@@ -385,7 +385,10 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleServerError(throwable: Throwable): Effect[http4s.Response[Effect]] =
+  def handleServerError(
+      request: http4s.Request[Effect],
+      throwable: Throwable
+  ): Effect[http4s.Response[Effect]] =
     Effect.pure(serverErrorResponse(throwableToServerError(throwable)))
 
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Endpoints.scala
@@ -371,7 +371,10 @@ trait EndpointsWithCustomErrors extends algebra.EndpointsWithCustomErrors with M
     *
     * This method can be overridden to customize the error reporting logic.
     */
-  def handleClientErrors(request: http4s.Request[Effect], invalid: Invalid): Effect[http4s.Response[Effect]] =
+  def handleClientErrors(
+      request: http4s.Request[Effect],
+      invalid: Invalid
+  ): Effect[http4s.Response[Effect]] =
     Effect.pure(clientErrorsResponse(invalidToClientErrors(invalid)))
 
   /** This method is called by ''endpoints'' when an exception is thrown during

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -83,7 +83,7 @@ private object JsonEntities {
         decoder.decode(value) match {
           case Valid(a) => endpoints.Effect.pure(Right(a))
           case inv: Invalid =>
-            endpoints.Effect.map(endpoints.handleClientErrors(inv))(Left.apply)
+            endpoints.Effect.map(endpoints.handleClientErrors(req, inv))(Left.apply)
         }
       }
     }


### PR DESCRIPTION
This MR adds the http4s request to the `handleClientErrors` so it can be used for e.g. logging.

It also removes a VM argument that doesn't seem to exist anymore on Java15