### PR TITLE
Add JsonSchema.lazySchema

### DIFF
--- a/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
@@ -166,8 +166,9 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
     )
   }
 
-  private def lazySchema[A](
-      schema: => JsonSchema[A]
+  def lazySchema[A](
+      schema: => JsonSchema[A],
+      name: String
   ): JsonSchema[A] = {
     // The schema won’t be evaluated until its `encoder` or `decoder` is effectively used
     lazy val evaluatedSchema = schema
@@ -178,11 +179,6 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
         Decoder.instance(c => evaluatedSchema.decoder(c))
     }
   }
-
-  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
-  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
 
   def emptyRecord: Record[Unit] =
     Record(

--- a/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
@@ -107,6 +107,21 @@ class JsonSchemasTest extends AnyFreeSpec {
     )
     assert(JsonSchemasCodec.recursiveSchema.encoder(rec) == json)
   }
+  "recursive expression type" in {
+    val json = Json.obj(
+      "x" -> Json.obj("x" -> Json.fromInt(1), "y" -> Json.fromInt(2)),
+      "y" -> Json.fromInt(3)
+    )
+    val expr = JsonSchemasCodec.Expression.Add(
+      JsonSchemasCodec.Expression
+        .Add(JsonSchemasCodec.Expression.Literal(1), JsonSchemasCodec.Expression.Literal(2)),
+      JsonSchemasCodec.Expression.Literal(3)
+    )
+    assert(
+      JsonSchemasCodec.expressionSchema.decoder.decodeJson(json).exists(_ == expr)
+    )
+    assert(JsonSchemasCodec.expressionSchema.encoder(expr) == json)
+  }
 
   "tuple" in {
     val json = Json.arr(Json.True, Json.fromInt(42), Json.fromString("foo"))

--- a/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
@@ -99,9 +99,7 @@ class JsonSchemasTest extends AnyFreeSpec {
     def namedEnum[A](schema: Enum[A], name: String): Enum[A] =
       s"'$name'!($schema)"
 
-    def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-      s"=>'$name'!($schema)"
-    def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
+    def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] =
       s"=>'$name'!($schema)"
 
     def emptyRecord: String =

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
@@ -112,8 +112,9 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
     )
   }
 
-  private def lazySchema[A](
-      schema: => JsonSchema[A]
+  def lazySchema[A](
+      schema: => JsonSchema[A],
+      name: String
   ): JsonSchema[A] = {
     // The schema won’t be evaluated until its `reads` or `writes` is effectively used
     lazy val evaluatedSchema = schema
@@ -122,11 +123,6 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
       def writes: Writes[A] = Writes(a => evaluatedSchema.writes.writes(a))
     }
   }
-
-  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
-  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
 
   def emptyRecord: Record[Unit] =
     Record(

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints4s/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints4s/playjson/JsonSchemasTest.scala
@@ -344,6 +344,16 @@ class JsonSchemasTest extends AnyFreeSpec {
       Recursive(Some(Recursive(Some(Recursive(None)))))
     )
   }
+  "recursive expression type" in {
+    testRoundtrip(
+      expressionSchema,
+      Json.obj("x" -> Json.obj("x" -> JsNumber(1), "y" -> JsNumber(2)), "y" -> JsNumber(3)),
+      Expression.Add(
+        Expression.Add(Expression.Literal(1), Expression.Literal(2)),
+        Expression.Literal(3)
+      )
+    )
+  }
 
   "tuple" in {
     testRoundtrip(

--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -214,6 +214,24 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * {{{
     *   case class Recursive(next: Option[Recursive])
     *   val recursiveSchema: Record[Recursive] = (
+    *     optField("next")(lazySchema(recursiveSchema, "Rec"))
+    *   ).xmap(Recursive)(_.next)
+    * }}}
+    *
+    * Interpreters should return a JsonSchema value that does not evaluate
+    * the given `schema` unless it is effectively used.
+    *
+    * @param schema The JSON schema whose evaluation should be delayed
+    * @param name A unique name identifying the schema
+    * @group operations
+    */
+  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A]
+
+  /** Captures a lazy reference to a JSON schema currently being defined:
+    *
+    * {{{
+    *   case class Recursive(next: Option[Recursive])
+    *   val recursiveSchema: Record[Recursive] = (
     *     optField("next")(lazyRecord(recursiveSchema, "Rec"))
     *   ).xmap(Recursive)(_.next)
     * }}}
@@ -225,7 +243,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param name A unique name identifying the schema
     * @group operations
     */
-  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A]
+  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
+    lazySchema(schema, name)
 
   /** Captures a lazy reference to a JSON schema currently being defined.
     *
@@ -236,7 +255,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param name A unique name identifying the schema
     * @group operations
     */
-  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A]
+  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
+    lazySchema(schema, name)
 
   /** The JSON schema of a record with no fields
     *

--- a/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
@@ -119,13 +119,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
       val encoder = tpe.encoder
     }
 
-  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-    new JsonSchema[A] {
-      val decoder = json => schema.decoder.decode(json)
-      val encoder = value => schema.encoder.encode(value)
-    }
-
-  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
+  def lazySchema[A](schema: => JsonSchema[A], name: String): JsonSchema[A] =
     new JsonSchema[A] {
       val decoder = json => schema.decoder.decode(json)
       val encoder = value => schema.encoder.encode(value)

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
@@ -143,6 +143,68 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
     Fixtures.toSchema(Fixtures.recursiveSchema.docs) shouldBe expectedSchema
   }
 
+  "Recursive expression" in {
+    val recSchema =
+      Schema.Reference(
+        "Expression",
+        Some(
+          Schema.OneOf(
+            Schema.EnumeratedAlternatives(
+              Schema.Primitive("integer", Some("int32"), None, None, None) ::
+                Schema.Object(
+                  Schema.Property(
+                    "x",
+                    Schema.Reference("Expression", None, None),
+                    isRequired = true,
+                    description = None
+                  ) :: Schema.Property(
+                    "y",
+                    Schema.Reference("Expression", None, None),
+                    isRequired = true,
+                    description = None
+                  ) :: Nil,
+                  additionalProperties = None,
+                  description = None,
+                  example = None,
+                  title = None
+                ) :: Nil
+            ),
+            None,
+            None,
+            None
+          )
+        ),
+        None
+      )
+    val expectedSchema =
+      Schema.OneOf(
+        Schema.EnumeratedAlternatives(
+          Schema.Primitive("integer", Some("int32"), None, None, None) ::
+            Schema.Object(
+              Schema.Property(
+                "x",
+                recSchema,
+                isRequired = true,
+                description = None
+              ) :: Schema.Property(
+                "y",
+                recSchema,
+                isRequired = true,
+                description = None
+              ) :: Nil,
+              additionalProperties = None,
+              description = None,
+              example = None,
+              title = None
+            ) :: Nil
+        ),
+        None,
+        None,
+        None
+      )
+    Fixtures.toSchema(Fixtures.expressionSchema.docs) shouldBe expectedSchema
+  }
+
   "Refining JSON schemas preserves documentation" should {
     "JsonSchema" in {
       val expectedSchema = Fixtures.intJsonSchema.docs

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
@@ -17,9 +17,9 @@ class JsonSchemasTest extends AnyFreeSpec {
           "s",
           DocumentedJsonSchemas.defaultStringJsonSchema.docs,
           isOptional = false,
-          documentation = None,
+          documentation = None
         ) :: Nil
-      ),
+      )
     ) ::
       (
         "Baz",
@@ -28,9 +28,9 @@ class JsonSchemasTest extends AnyFreeSpec {
             "i",
             DocumentedJsonSchemas.intJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) :: Nil
-        ),
+        )
       ) ::
       ("Bax", DocumentedRecord(Nil)) ::
       ("Qux", DocumentedRecord(Nil)) ::
@@ -41,9 +41,9 @@ class JsonSchemasTest extends AnyFreeSpec {
             "b",
             DocumentedJsonSchemas.byteJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) :: Nil
-        ),
+        )
       ) ::
       Nil
   )
@@ -55,13 +55,13 @@ class JsonSchemasTest extends AnyFreeSpec {
           "name",
           DocumentedJsonSchemas.defaultStringJsonSchema.docs,
           isOptional = false,
-          documentation = Some("Name of the user"),
+          documentation = Some("Name of the user")
         ) ::
           Field(
             "age",
             DocumentedJsonSchemas.intJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) ::
           Nil
       )
@@ -85,7 +85,7 @@ class JsonSchemasTest extends AnyFreeSpec {
       DocumentedEnum(
         DocumentedJsonSchemas.defaultStringJsonSchema.docs,
         ujson.Str("Red") :: ujson.Str("Blue") :: Nil,
-        Some("Color"),
+        Some("Color")
       )
     assert(DocumentedJsonSchemas.Enum.colorSchema.docs == expectedSchema)
   }
@@ -98,7 +98,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             "quux",
             DocumentedJsonSchemas.defaultStringJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) :: Nil
         ),
         ujson.Obj("quux" -> ujson.Str("bar")) :: ujson.Obj(
@@ -106,7 +106,7 @@ class JsonSchemasTest extends AnyFreeSpec {
         ) :: Nil,
         None,
         None,
-        None,
+        None
       )
     assert(
       DocumentedJsonSchemas.NonStringEnum.enumSchema.docs == expectedSchema
@@ -121,7 +121,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             None,
             None,
             None,
-            None,
+            None
           ) =>
         assert(tpe.isInstanceOf[LazySchema])
       case _ =>
@@ -131,11 +131,49 @@ class JsonSchemasTest extends AnyFreeSpec {
     }
   }
 
+  "recursive expression" in {
+    DocumentedJsonSchemas.expressionSchema.docs match {
+      case OneOf(
+            List(
+              Primitive(
+                "integer",
+                Some("int32"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+              ),
+              DocumentedRecord(
+                List(Field("x", tpex, false, None), Field("y", tpey, false, None)),
+                None,
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          ) =>
+        assert(tpex.isInstanceOf[LazySchema])
+        assert(tpey.isInstanceOf[LazySchema])
+      case _ =>
+        fail(
+          s"Unexpected type for 'recSchema': ${DocumentedJsonSchemas.expressionSchema.docs}"
+        )
+    }
+  }
+
   "maps" in {
     val expected = DocumentedRecord(
       Nil,
       Some(DocumentedJsonSchemas.intJsonSchema.docs),
-      None,
+      None
     )
     assert(DocumentedJsonSchemas.intDictionary.docs == expected)
   }
@@ -156,7 +194,7 @@ class JsonSchemasTest extends AnyFreeSpec {
       minimum = Some(0.0),
       maximum = Some(10.0),
       exclusiveMaximum = Some(true),
-      multipleOf = Some(2.0),
+      multipleOf = Some(2.0)
     )
 
     assert(DocumentedJsonSchemas.constraintNumericSchema.docs == expected)


### PR DESCRIPTION
Allow more general recursive schemas than `lazyRecord` or `lazyTagged`. For instance schema for an expression language like:

```scala
sealed trait Expression
object Expression {
  case class Literal(value: Int) extends Expression
  case class Add(x: Expression, y: Expression) extends Expression
}
val expressionSchema: JsonSchema[Expression] = {
  implicit val self: JsonSchema[Expression] = lazySchema(expressionSchema, "Expression")
  intJsonSchema
    .orFallbackTo(field[Expression]("x") zip field[Expression]("y"))
    .xmap[Expression] {
      case Left(value)   => Expression.Literal(value)
      case Right((x, y)) => Expression.Add(x, y)
    } {
      case Expression.Literal(value) => Left(value)
      case Expression.Add(x, y)      => Right((x, y))
    }
}
```

Which supports JSON like:

```json
{"x": 1, "y": {"x": 2, "y": 3}}
```

Maybe `JsonSchema.lazyRecord` and `JsonSchema.lazyRecord` could be deprecated since they are just redefinitions of `JsonSchema.lazySchema` ?