### PR TITLE
Add JsonSchema.lazySchema.

### DIFF
--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -16,7 +16,7 @@ val `akka-http-client` =
       `scala 2.12 to dotty`,
       name := "akka-http-client",
       version := "3.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-stream" % akkaActorVersion).cross(CrossVersion.for3Use2_13),
         ("com.typesafe.akka" %% "akka-http" % akkaHttpVersion).cross(CrossVersion.for3Use2_13),
@@ -43,7 +43,7 @@ val `akka-http-server` =
       `scala 2.12 to dotty`,
       name := "akka-http-server",
       version := "4.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-http" % akkaHttpVersion).cross(CrossVersion.for3Use2_13),
         ("com.typesafe.akka" %% "akka-stream" % akkaActorVersion).cross(CrossVersion.for3Use2_13),

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / sonatypeProjectHosting := Some(
 // We want to keep binary compatibility as long as we can for the algebra,
 // but it is OK to publish breaking releases of interpreters. So,
 // interpreter modules may override this setting.
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // Default version, used by the algebra modules, and by the interpreters,
 // unless they override it.
 ThisBuild / version := "1.3.0+n"

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -36,7 +36,7 @@ val `http4s-client` =
       `scala 2.12 to dotty`,
       name := "http4s-client",
       version := "3.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-client" % http4sVersion).cross(CrossVersion.for3Use2_13),
         ("org.http4s" %% "http4s-async-http-client" % http4sVersion % Test).cross(CrossVersion.for3Use2_13)

--- a/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
@@ -166,9 +166,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
     )
   }
 
-  private def lazySchema[A](
-      schema: => JsonSchema[A]
-  ): JsonSchema[A] = {
+  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] = {
     // The schema won’t be evaluated until its `encoder` or `decoder` is effectively used
     lazy val evaluatedSchema = schema
     new JsonSchema[A] {
@@ -180,9 +178,9 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
   }
 
   def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
+    lazySchema(name)(schema)
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
+    lazySchema(name)(schema)
 
   def emptyRecord: Record[Unit] =
     Record(

--- a/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
+++ b/json-schema/json-schema-circe/src/main/scala/endpoints4s/circe/JsonSchemas.scala
@@ -166,7 +166,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
     )
   }
 
-  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] = {
+  override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] = {
     // The schema won’t be evaluated until its `encoder` or `decoder` is effectively used
     lazy val evaluatedSchema = schema
     new JsonSchema[A] {

--- a/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
@@ -107,6 +107,31 @@ class JsonSchemasTest extends AnyFreeSpec {
     )
     assert(JsonSchemasCodec.recursiveSchema.encoder(rec) == json)
   }
+  "recursive expression type" in {
+    val json = Json.obj(
+      "x" -> Json.obj("x" -> Json.fromInt(1), "y" -> Json.fromInt(2)),
+      "y" -> Json.fromInt(3)
+    )
+    val expr = JsonSchemasCodec.Expression.Add(
+      JsonSchemasCodec.Expression
+        .Add(JsonSchemasCodec.Expression.Literal(1), JsonSchemasCodec.Expression.Literal(2)),
+      JsonSchemasCodec.Expression.Literal(3)
+    )
+    assert(
+      JsonSchemasCodec.expressionSchema.decoder.decodeJson(json).exists(_ == expr)
+    )
+    assert(JsonSchemasCodec.expressionSchema.encoder(expr) == json)
+  }
+  "mutually recursive types" in {
+    val json = Json.obj("b" -> Json.obj("a" -> Json.obj()))
+    val rec = JsonSchemasCodec.MutualRecursiveA(
+      Some(JsonSchemasCodec.MutualRecursiveB(Some(JsonSchemasCodec.MutualRecursiveA(None))))
+    )
+    assert(
+      JsonSchemasCodec.mutualRecursiveA.decoder.decodeJson(json).exists(_ == rec)
+    )
+    assert(JsonSchemasCodec.mutualRecursiveA.encoder(rec) == json)
+  }
 
   "tuple" in {
     val json = Json.arr(Json.True, Json.fromInt(42), Json.fromString("foo"))

--- a/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
@@ -141,6 +141,29 @@ class JsonSchemasTest extends AnyFreeSpec {
     )
     assert(JsonSchemasCodec.mutualRecursiveB.encoder(recB) == jsonB)
   }
+  "recursive tagged" in {
+    val json = Json.obj(
+      "kind" -> Json.fromString("A"),
+      "a" -> Json.fromString("foo"),
+      "next" -> Json.obj(
+        "kind" -> Json.fromString("B"),
+        "b" -> Json.fromInt(42)
+      )
+    )
+    val rec = JsonSchemasCodec.TaggedRecursiveA(
+      a = "foo",
+      next = Some(
+        JsonSchemasCodec.TaggedRecursiveB(
+          b = 42,
+          next = None
+        )
+      )
+    )
+    assert(
+      JsonSchemasCodec.taggedRecursiveSchema.decoder.decodeJson(json).exists(_ == rec)
+    )
+    assert(JsonSchemasCodec.taggedRecursiveSchema.encoder(rec) == json)
+  }
 
   "tuple" in {
     val json = Json.arr(Json.True, Json.fromInt(42), Json.fromString("foo"))

--- a/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
+++ b/json-schema/json-schema-circe/src/test/scala/endpoints4s/circe/JsonSchemasTest.scala
@@ -123,14 +123,23 @@ class JsonSchemasTest extends AnyFreeSpec {
     assert(JsonSchemasCodec.expressionSchema.encoder(expr) == json)
   }
   "mutually recursive types" in {
-    val json = Json.obj("b" -> Json.obj("a" -> Json.obj()))
-    val rec = JsonSchemasCodec.MutualRecursiveA(
+    val jsonA = Json.obj("b" -> Json.obj("a" -> Json.obj()))
+    val recA = JsonSchemasCodec.MutualRecursiveA(
       Some(JsonSchemasCodec.MutualRecursiveB(Some(JsonSchemasCodec.MutualRecursiveA(None))))
     )
     assert(
-      JsonSchemasCodec.mutualRecursiveA.decoder.decodeJson(json).exists(_ == rec)
+      JsonSchemasCodec.mutualRecursiveA.decoder.decodeJson(jsonA).exists(_ == recA)
     )
-    assert(JsonSchemasCodec.mutualRecursiveA.encoder(rec) == json)
+    assert(JsonSchemasCodec.mutualRecursiveA.encoder(recA) == jsonA)
+
+    val jsonB = Json.obj("a" -> Json.obj("b" -> Json.obj()))
+    val recB = JsonSchemasCodec.MutualRecursiveB(
+      Some(JsonSchemasCodec.MutualRecursiveA(Some(JsonSchemasCodec.MutualRecursiveB(None))))
+    )
+    assert(
+      JsonSchemasCodec.mutualRecursiveB.decoder.decodeJson(jsonB).exists(_ == recB)
+    )
+    assert(JsonSchemasCodec.mutualRecursiveB.encoder(recB) == jsonB)
   }
 
   "tuple" in {

--- a/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
@@ -105,6 +105,10 @@ class JsonSchemasTest extends AnyFreeSpec {
       s"=>'$name'!($schema)"
     override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
       s"=>'$name'!($schema)"
+    override def lazyRecord[A](name: String)(schema: => Record[A]): Record[A] =
+      s"=>'$name'!($schema)"
+    override def lazyTagged[A](name: String)(schema: => Tagged[A]): Tagged[A] =
+      s"=>'$name'!($schema)"
 
     def emptyRecord: String =
       "%"

--- a/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
@@ -103,7 +103,7 @@ class JsonSchemasTest extends AnyFreeSpec {
       s"=>'$name'!($schema)"
     def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
       s"=>'$name'!($schema)"
-    def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
+    override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
       s"=>'$name'!($schema)"
 
     def emptyRecord: String =

--- a/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
+++ b/json-schema/json-schema-generic/src/test/scala/endpoints4s/generic/JsonSchemasTest.scala
@@ -103,6 +103,8 @@ class JsonSchemasTest extends AnyFreeSpec {
       s"=>'$name'!($schema)"
     def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
       s"=>'$name'!($schema)"
+    def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
+      s"=>'$name'!($schema)"
 
     def emptyRecord: String =
       "%"

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
@@ -112,7 +112,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
     )
   }
 
-  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] = {
+  override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] = {
     // The schema won’t be evaluated until its `reads` or `writes` is effectively used
     lazy val evaluatedSchema = schema
     new JsonSchema[A] {

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
@@ -126,6 +126,28 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
     lazySchema(name)(schema)
 
+  override def lazyRecord[A](name: String)(schema: => Record[A]): Record[A] = {
+    // The schema won’t be evaluated until its `reads` or `writes` is effectively used
+    lazy val evaluatedSchema = schema
+    Record(
+      Reads(js => evaluatedSchema.reads.reads(js)),
+      OWrites(a => evaluatedSchema.writes.writes(a))
+    )
+  }
+
+  override def lazyTagged[A](name: String)(schema: => Tagged[A]): Tagged[A] = {
+    // The schema won’t be evaluated until its `reads` or `writes` is effectively used
+    lazy val evaluatedSchema = schema
+    new Tagged[A] {
+      override def discriminator: String =
+        evaluatedSchema.discriminator
+      def tagAndJson(a: A): (String, JsObject) =
+        evaluatedSchema.tagAndJson(a)
+      def findReads(tagName: String): Option[Reads[A]] =
+        evaluatedSchema.findReads(tagName)
+    }
+  }
+
   def emptyRecord: Record[Unit] =
     Record(
       new Reads[Unit] {

--- a/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
+++ b/json-schema/json-schema-playjson/src/main/scala/endpoints4s/playjson/JsonSchemas.scala
@@ -112,9 +112,7 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
     )
   }
 
-  private def lazySchema[A](
-      schema: => JsonSchema[A]
-  ): JsonSchema[A] = {
+  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] = {
     // The schema won’t be evaluated until its `reads` or `writes` is effectively used
     lazy val evaluatedSchema = schema
     new JsonSchema[A] {
@@ -124,9 +122,9 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
   }
 
   def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
+    lazySchema(name)(schema)
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
-    lazySchema(schema)
+    lazySchema(name)(schema)
 
   def emptyRecord: Record[Unit] =
     Record(

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints4s/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints4s/playjson/JsonSchemasTest.scala
@@ -344,6 +344,23 @@ class JsonSchemasTest extends AnyFreeSpec {
       Recursive(Some(Recursive(Some(Recursive(None)))))
     )
   }
+  "recursive expression type" in {
+    testRoundtrip(
+      expressionSchema,
+      Json.obj("x" -> Json.obj("x" -> JsNumber(1), "y" -> JsNumber(2)), "y" -> JsNumber(3)),
+      Expression.Add(
+        Expression.Add(Expression.Literal(1), Expression.Literal(2)),
+        Expression.Literal(3)
+      )
+    )
+  }
+  "mutually recursive types" in {
+    testRoundtrip(
+      mutualRecursiveA,
+      Json.obj("b" -> Json.obj("a" -> Json.obj())),
+      MutualRecursiveA(Some(MutualRecursiveB(Some(MutualRecursiveA(None)))))
+    )
+  }
 
   "tuple" in {
     testRoundtrip(

--- a/json-schema/json-schema-playjson/src/test/scala/endpoints4s/playjson/JsonSchemasTest.scala
+++ b/json-schema/json-schema-playjson/src/test/scala/endpoints4s/playjson/JsonSchemasTest.scala
@@ -361,6 +361,28 @@ class JsonSchemasTest extends AnyFreeSpec {
       MutualRecursiveA(Some(MutualRecursiveB(Some(MutualRecursiveA(None)))))
     )
   }
+  "recursive tagged" in {
+    testRoundtrip(
+      taggedRecursiveSchema,
+      Json.obj(
+        "kind" -> JsString("A"),
+        "a" -> JsString("foo"),
+        "next" -> Json.obj(
+          "kind" -> JsString("B"),
+          "b" -> JsNumber(42)
+        )
+      ),
+      JsonSchemasCodec.TaggedRecursiveA(
+        a = "foo",
+        next = Some(
+          JsonSchemasCodec.TaggedRecursiveB(
+            b = 42,
+            next = None
+          )
+        )
+      )
+    )
+  }
 
   "tuple" in {
     testRoundtrip(

--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -225,6 +225,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param name A unique name identifying the schema
     * @group operations
     */
+  @deprecated("Use `lazySchema` instead", "1.4.0")
   def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A]
 
   /** Captures a lazy reference to a JSON schema currently being defined.
@@ -236,6 +237,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param name A unique name identifying the schema
     * @group operations
     */
+  @deprecated("Use `lazySchema` instead", "1.4.0")
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A]
 
   /** A lazy JSON schema that can references schemas currently being defined:
@@ -254,7 +256,8 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param schema The record JSON schema whose evaluation should be delayed
     * @group operations
     */
-  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A]
+  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
+    sys.error(s"Unsupported algebra version: 1.4.0. Please update your interpreter.")
 
   /** The JSON schema of a record with no fields
     *

--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -238,6 +238,24 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     */
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A]
 
+  /** A lazy JSON schema that can references schemas currently being defined:
+    *
+    * {{{
+    *   case class Recursive(next: Option[Recursive])
+    *   val recursiveSchema: JsonSchema[Recursive] = lazySchema("Rec")(
+    *     optField("next")(recursiveSchema)
+    *   ).xmap(Recursive)(_.next)
+    * }}}
+    *
+    * Interpreters should return a JsonSchema value that does not evaluate
+    * the given `schema` unless it is effectively used.
+    *
+    * @param name A unique name identifying the schema
+    * @param schema The record JSON schema whose evaluation should be delayed
+    * @group operations
+    */
+  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A]
+
   /** The JSON schema of a record with no fields
     *
     *   - Encoder interpreters produce an empty JSON object,

--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -225,7 +225,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param name A unique name identifying the schema
     * @group operations
     */
-  @deprecated("Use `lazySchema` instead", "1.4.0")
+  @deprecated("Use `lazyRecord(name)(...)` instead", "1.4.0")
   def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A]
 
   /** Captures a lazy reference to a JSON schema currently being defined.
@@ -237,8 +237,40 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     * @param name A unique name identifying the schema
     * @group operations
     */
-  @deprecated("Use `lazySchema` instead", "1.4.0")
+  @deprecated("Use `lazyTagged(name)(...)` instead", "1.4.0")
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A]
+
+  /** Captures a lazy reference to a JSON schema currently being defined:
+    *
+    * {{{
+    *   case class Recursive(next: Option[Recursive])
+    *   val recursiveSchema: Record[Recursive] =
+    *     lazyRecord("Rec") {
+    *       optField("next")(recursiveSchema)
+    *     }.xmap(Recursive(_))(_.next)
+    * }}}
+    *
+    * Interpreters should return a JsonSchema value that does not evaluate
+    * the given `schema` unless it is effectively used.
+    *
+    * @param name A unique name identifying the schema
+    * @param schema The record JSON schema whose evaluation should be delayed
+    * @group operations
+    */
+  def lazyRecord[A](name: String)(schema: => Record[A]): Record[A] =
+    sys.error(s"Unsupported algebra version: 1.4.0. Please update your interpreter.")
+
+  /** Captures a lazy reference to a JSON schema currently being defined.
+    *
+    * Interpreters should return a JsonSchema value that does not evaluate
+    * the given `schema` unless it is effectively used.
+    *
+    * @param name A unique name identifying the schema
+    * @param schema The tagged JSON schema whose evaluation should be delayed
+    * @group operations
+    */
+  def lazyTagged[A](name: String)(schema: => Tagged[A]): Tagged[A] =
+    sys.error(s"Unsupported algebra version: 1.4.0. Please update your interpreter.")
 
   /** A lazy JSON schema that can references schemas currently being defined:
     *

--- a/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasDocs.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasDocs.scala
@@ -66,7 +66,7 @@ trait JsonSchemasDocs extends JsonSchemas {
   case class Recursive(next: Option[Recursive])
 
   val recursiveSchema: Record[Recursive] = (
-    optField("next")(lazyRecord(recursiveSchema, "Rec"))
+    optField("next")(lazySchema("Rec")(recursiveSchema))
   ).xmap(Recursive(_))(_.next)
   //#recursive
 

--- a/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasFixtures.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasFixtures.scala
@@ -95,7 +95,7 @@ trait JsonSchemasFixtures extends JsonSchemas {
 
   case class Recursive(next: Option[Recursive])
   val recursiveSchema: Record[Recursive] = (
-    optField("next")(lazyRecord(recursiveSchema, "Rec"))
+    optField("next")(lazySchema("Rec")(recursiveSchema))
   ).xmap(Recursive(_))(_.next)
 
   sealed trait Expression

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -7,8 +7,8 @@ lazy val openapi =
     .crossType(CrossType.Pure)
     .in(file("openapi"))
     .settings(
-      version := "2.1.0",
-      versionPolicyIntention := Compatibility.BinaryCompatible,
+      version := "2.0.0+n",
+      versionPolicyIntention := Compatibility.None,
       publishSettings,
       `scala 2.12 to dotty`,
       name := "openapi",

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -7,8 +7,8 @@ lazy val openapi =
     .crossType(CrossType.Pure)
     .in(file("openapi"))
     .settings(
-      version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      version := "2.1.0",
+      versionPolicyIntention := Compatibility.BinaryCompatible,
       publishSettings,
       `scala 2.12 to dotty`,
       name := "openapi",

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -116,29 +116,14 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
     // A documented JSON schema that is unevaluated unless its `value` is accessed
     sealed abstract class LazySchema extends DocumentedJsonSchema {
+      val name: String
       def value: DocumentedJsonSchema
     }
 
     object LazySchema {
 
-      def apply(s: => DocumentedJsonSchema): LazySchema =
+      def apply(n: String, s: => DocumentedJsonSchema): LazySchema =
         new LazySchema {
-          lazy val value: DocumentedJsonSchema = s
-          def description: Option[String] = value.description
-          def example: Option[ujson.Value] = value.example
-          def title: Option[String] = value.title
-        }
-    }
-
-    sealed abstract class RecursiveSchema extends DocumentedJsonSchema {
-      val name: String
-      def value: DocumentedJsonSchema
-    }
-
-    object RecursiveSchema {
-
-      def apply(n: String, s: => DocumentedJsonSchema): RecursiveSchema =
-        new RecursiveSchema {
           val name: String = n
           lazy val value: DocumentedJsonSchema = s
           def description: Option[String] = value.description
@@ -241,23 +226,15 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   def namedEnum[A](schema: Enum[A], name: String): Enum[A] =
     new Enum(schema.ujsonSchema, schema.docs.copy(name = Some(name)))
 
-  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
-    new JsonSchema(
-      ujsonSchemas.lazyRecord(schema.ujsonSchema, name),
-      LazySchema(namedRecord(schema, name).docs)
-    )
-
-  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
-    new JsonSchema(
-      ujsonSchemas.lazyTagged(schema.ujsonSchema, name),
-      LazySchema(namedTagged(schema, name).docs)
-    )
-
   override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
     new JsonSchema(
       ujsonSchemas.lazySchema(name)(schema.ujsonSchema),
-      RecursiveSchema(name, schema.docs)
+      LazySchema(name, schema.docs)
     )
+  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
+    lazySchema(name)(schema)
+  def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
+    lazySchema(name)(schema)
 
   def emptyRecord: Record[Unit] =
     new Record(ujsonSchemas.emptyRecord, DocumentedRecord(Nil))
@@ -356,8 +333,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         case s: Primitive        => s.copy(example = Some(exampleJson))
         case s: Array            => s.copy(example = Some(exampleJson))
         case s: DocumentedEnum   => s.copy(example = Some(exampleJson))
-        case s: LazySchema       => LazySchema(updatedDocs(s.value))
-        case s: RecursiveSchema  => RecursiveSchema(s.name, updatedDocs(s.value))
+        case s: LazySchema       => LazySchema(s.name, updatedDocs(s.value))
         case s: OneOf            => s.copy(example = Some(exampleJson))
       }
     new JsonSchema(
@@ -404,8 +380,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         case s: Primitive        => s.copy(title = Some(title))
         case s: Array            => s.copy(title = Some(title))
         case s: DocumentedEnum   => s.copy(title = Some(title))
-        case s: LazySchema       => LazySchema(updatedDocs(s.value))
-        case s: RecursiveSchema  => RecursiveSchema(s.name, updatedDocs(s.value))
+        case s: LazySchema       => LazySchema(s.name, updatedDocs(s.value))
         case s: OneOf            => s.copy(title = Some(title))
       }
     new JsonSchema(
@@ -452,8 +427,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         case s: Primitive        => s.copy(description = Some(description))
         case s: Array            => s.copy(description = Some(description))
         case s: DocumentedEnum   => s.copy(description = Some(description))
-        case s: LazySchema       => LazySchema(updatedDocs(s.value))
-        case s: RecursiveSchema  => RecursiveSchema(s.name, updatedDocs(s.value))
+        case s: LazySchema       => LazySchema(s.name, updatedDocs(s.value))
         case s: OneOf            => s.copy(description = Some(description))
       }
     new JsonSchema(
@@ -889,13 +863,11 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
           title
         )
       case lzy: LazySchema =>
-        toSchema(lzy.value, coprodBase, referencedSchemas)
-      case rec: RecursiveSchema =>
-        if (referencedSchemas(rec.name)) Schema.Reference(rec.name, None, None)
+        if (referencedSchemas(lzy.name)) Schema.Reference(lzy.name, None, None)
         else
           Schema.Reference(
-            rec.name,
-            Some(toSchema(rec.value, coprodBase, referencedSchemas + rec.name)),
+            lzy.name,
+            Some(toSchema(lzy.value, coprodBase, referencedSchemas + lzy.name)),
             None
           )
       case OneOf(alternatives, description, example, title) =>

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -116,15 +116,11 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
     // A documented JSON schema that is unevaluated unless its `value` is accessed
     sealed abstract class LazySchema extends DocumentedJsonSchema {
-      def name: String =
-        sys.error(s"Unsupported algebra version: 2.1.0. Please update your interpreter.")
+      def name: String
       def value: DocumentedJsonSchema
     }
 
     object LazySchema {
-
-      def apply(s: => DocumentedJsonSchema): LazySchema =
-        sys.error(s"Unsupported algebra version: 2.1.0. Please update your interpreter.")
 
       def apply(n: String, s: => DocumentedJsonSchema): LazySchema =
         new LazySchema {

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -253,7 +253,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       LazySchema(namedTagged(schema, name).docs)
     )
 
-  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
+  override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
     new JsonSchema(
       ujsonSchemas.lazySchema(name)(schema.ujsonSchema),
       RecursiveSchema(name, schema.docs)

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -116,15 +116,19 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
     // A documented JSON schema that is unevaluated unless its `value` is accessed
     sealed abstract class LazySchema extends DocumentedJsonSchema {
-      val name: String
+      def name: String =
+        sys.error(s"Unsupported algebra version: 2.1.0. Please update your interpreter.")
       def value: DocumentedJsonSchema
     }
 
     object LazySchema {
 
+      def apply(s: => DocumentedJsonSchema): LazySchema =
+        sys.error(s"Unsupported algebra version: 2.1.0. Please update your interpreter.")
+
       def apply(n: String, s: => DocumentedJsonSchema): LazySchema =
         new LazySchema {
-          val name: String = n
+          override val name: String = n
           lazy val value: DocumentedJsonSchema = s
           def description: Option[String] = value.description
           def example: Option[ujson.Value] = value.example

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -63,10 +63,10 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       def additionalProperties: Option[DocumentedJsonSchema]
       def name: Option[String]
 
-      def withName(name: Option[String]): DocumentedRecord
-      def withExample(example: => Option[ujson.Value]): DocumentedRecord
-      def withTitle(title: Option[String]): DocumentedRecord
-      def withDescription(description: Option[String]): DocumentedRecord
+      def withName(name: String): DocumentedRecord
+      def withExample(example: => ujson.Value): DocumentedRecord
+      def withTitle(title: String): DocumentedRecord
+      def withDescription(description: String): DocumentedRecord
     }
     object DocumentedRecord {
 
@@ -78,41 +78,39 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
           example: Option[ujson.Value] = None,
           title: Option[String] = None
       ) extends DocumentedRecord {
-        def withName(name: Option[String]): DocumentedRecord =
-          copy(name = name)
-        def withExample(example: => Option[ujson.Value]): DocumentedRecord =
-          copy(example = example)
-        def withTitle(title: Option[String]): DocumentedRecord =
-          copy(title = title)
-        def withDescription(description: Option[String]): DocumentedRecord =
-          copy(description = description)
+        def withName(name: String): DocumentedRecord =
+          copy(name = Some(name))
+        def withExample(example: => ujson.Value): DocumentedRecord =
+          copy(example = Some(example))
+        def withTitle(title: String): DocumentedRecord =
+          copy(title = Some(title))
+        def withDescription(description: String): DocumentedRecord =
+          copy(description = Some(description))
       }
 
-      class Lazy(name: String, docs: => DocumentedRecord) extends DocumentedRecord {
+      class Lazy(n: String, docs: => DocumentedRecord) extends DocumentedRecord {
         lazy val evaluatedDocs = docs
         def fields: List[Field] = evaluatedDocs.fields
         def additionalProperties: Option[DocumentedJsonSchema] =
           evaluatedDocs.additionalProperties
-        def name: Option[String] = Some(name)
+        def name: Option[String] = Some(n)
         def description: Option[String] = evaluatedDocs.description
         def example: Option[ujson.Value] = evaluatedDocs.example
         def title: Option[String] = evaluatedDocs.title
 
-        def withName(_name: Option[String]): DocumentedRecord =
-          new Lazy(name, this) {
-            override def name: Option[String] = _name
+        def withName(n: String): DocumentedRecord =
+          new Lazy(n, this)
+        def withExample(e: => ujson.Value): DocumentedRecord =
+          new Lazy(n, this) {
+            override def example: Option[ujson.Value] = Some(e)
           }
-        def withExample(_example: => Option[ujson.Value]): DocumentedRecord =
-          new Lazy(name, this) {
-            override def example: Option[ujson.Value] = _example
+        def withTitle(t: String): DocumentedRecord =
+          new Lazy(n, this) {
+            override def title: Option[String] = Some(t)
           }
-        def withTitle(_title: Option[String]): DocumentedRecord =
-          new Lazy(name, this) {
-            override def title: Option[String] = _title
-          }
-        def withDescription(_description: Option[String]): DocumentedRecord =
-          new Lazy(name, this) {
-            override def description: Option[String] = _description
+        def withDescription(d: String): DocumentedRecord =
+          new Lazy(n, this) {
+            override def description: Option[String] = Some(d)
           }
       }
 
@@ -141,10 +139,10 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
       def name: Option[String]
       def discriminatorName: String
 
-      def withName(name: Option[String]): DocumentedCoProd
-      def withExample(example: => Option[ujson.Value]): DocumentedCoProd
-      def withTitle(title: Option[String]): DocumentedCoProd
-      def withDescription(description: Option[String]): DocumentedCoProd
+      def withName(name: String): DocumentedCoProd
+      def withExample(example: => ujson.Value): DocumentedCoProd
+      def withTitle(title: String): DocumentedCoProd
+      def withDescription(description: String): DocumentedCoProd
       def withDiscriminatorName(discriminatorName: String): DocumentedCoProd
     }
 
@@ -157,46 +155,44 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
           example: Option[ujson.Value] = None,
           title: Option[String] = None
       ) extends DocumentedCoProd {
-        def withName(name: Option[String]): DocumentedCoProd =
-          copy(name = name)
-        def withExample(example: => Option[ujson.Value]): DocumentedCoProd =
-          copy(example = example)
-        def withTitle(title: Option[String]): DocumentedCoProd =
-          copy(title = title)
-        def withDescription(description: Option[String]): DocumentedCoProd =
-          copy(description = description)
+        def withName(name: String): DocumentedCoProd =
+          copy(name = Some(name))
+        def withExample(example: => ujson.Value): DocumentedCoProd =
+          copy(example = Some(example))
+        def withTitle(title: String): DocumentedCoProd =
+          copy(title = Some(title))
+        def withDescription(description: String): DocumentedCoProd =
+          copy(description = Some(description))
         def withDiscriminatorName(discriminatorName: String): DocumentedCoProd =
           copy(discriminatorName = discriminatorName)
       }
 
-      class Lazy(name: String, docs: => DocumentedCoProd) extends DocumentedCoProd {
+      class Lazy(n: String, docs: => DocumentedCoProd) extends DocumentedCoProd {
         lazy val evaluatedDocs = docs
         def alternatives: List[(String, DocumentedRecord)] = evaluatedDocs.alternatives
-        def name: Option[String] = Some(name)
+        def name: Option[String] = Some(n)
         def discriminatorName: String = evaluatedDocs.discriminatorName
         def description: Option[String] = evaluatedDocs.description
         def example: Option[ujson.Value] = evaluatedDocs.example
         def title: Option[String] = evaluatedDocs.title
 
-        def withName(_name: Option[String]): DocumentedCoProd =
-          new Lazy(name, this) {
-            override def name: Option[String] = _name
+        def withName(n: String): DocumentedCoProd =
+          new Lazy(n, this)
+        def withExample(e: => ujson.Value): DocumentedCoProd =
+          new Lazy(n, this) {
+            override def example: Option[ujson.Value] = Some(e)
           }
-        def withExample(_example: => Option[ujson.Value]): DocumentedCoProd =
-          new Lazy(name, this) {
-            override def example: Option[ujson.Value] = _example
+        def withTitle(t: String): DocumentedCoProd =
+          new Lazy(n, this) {
+            override def title: Option[String] = Some(t)
           }
-        def withTitle(_title: Option[String]): DocumentedCoProd =
-          new Lazy(name, this) {
-            override def title: Option[String] = _title
+        def withDescription(d: String): DocumentedCoProd =
+          new Lazy(n, this) {
+            override def description: Option[String] = Some(d)
           }
-        def withDescription(_description: Option[String]): DocumentedCoProd =
-          new Lazy(name, this) {
-            override def description: Option[String] = _description
-          }
-        def withDiscriminatorName(_discriminatorName: String): DocumentedCoProd =
-          new Lazy(name, null) {
-            override def discriminatorName: String = _discriminatorName
+        def withDiscriminatorName(d: String): DocumentedCoProd =
+          new Lazy(n, null) {
+            override def discriminatorName: String = d
           }
       }
 
@@ -346,10 +342,10 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   }
 
   def namedRecord[A](schema: Record[A], name: String): Record[A] =
-    new Record(schema.ujsonSchema, schema.docs.withName(Some(name)))
+    new Record(schema.ujsonSchema, schema.docs.withName(name))
 
   def namedTagged[A](schema: Tagged[A], name: String): Tagged[A] =
-    new Tagged(schema.ujsonSchema, schema.docs.withName(Some(name)))
+    new Tagged(schema.ujsonSchema, schema.docs.withName(name))
 
   def namedEnum[A](schema: Enum[A], name: String): Enum[A] =
     new Enum(schema.ujsonSchema, schema.docs.copy(name = Some(name)))
@@ -434,7 +430,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Record[A] =
     new Record[A](
       record.ujsonSchema,
-      record.docs.withExample(Some(record.ujsonSchema.codec.encode(example)))
+      record.docs.withExample(record.ujsonSchema.codec.encode(example))
     )
 
   def withExampleTagged[A](
@@ -443,7 +439,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Tagged[A] =
     new Tagged[A](
       tagged.ujsonSchema,
-      tagged.docs.withExample(Some(tagged.ujsonSchema.codec.encode(example)))
+      tagged.docs.withExample(tagged.ujsonSchema.codec.encode(example))
     )
 
   def withExampleEnum[A](
@@ -464,8 +460,8 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
     lazy val exampleJson = schema.ujsonSchema.codec.encode(example)
     def updatedDocs(djs: DocumentedJsonSchema): DocumentedJsonSchema =
       djs match {
-        case s: DocumentedRecord => s.withExample(Some(exampleJson))
-        case s: DocumentedCoProd => s.withExample(Some(exampleJson))
+        case s: DocumentedRecord => s.withExample(exampleJson)
+        case s: DocumentedCoProd => s.withExample(exampleJson)
         case s: Primitive        => s.copy(example = Some(exampleJson))
         case s: Array            => s.copy(example = Some(exampleJson))
         case s: DocumentedEnum   => s.copy(example = Some(exampleJson))
@@ -484,7 +480,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Record[A] =
     new Record[A](
       record.ujsonSchema,
-      record.docs.withTitle(Some(title))
+      record.docs.withTitle(title)
     )
 
   def withTitleTagged[A](
@@ -493,7 +489,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Tagged[A] =
     new Tagged[A](
       tagged.ujsonSchema,
-      tagged.docs.withTitle(Some(title))
+      tagged.docs.withTitle(title)
     )
 
   def withTitleEnum[A](
@@ -511,8 +507,8 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): JsonSchema[A] = {
     def updatedDocs(djs: DocumentedJsonSchema): DocumentedJsonSchema =
       djs match {
-        case s: DocumentedRecord => s.withTitle(Some(title))
-        case s: DocumentedCoProd => s.withTitle(Some(title))
+        case s: DocumentedRecord => s.withTitle(title)
+        case s: DocumentedCoProd => s.withTitle(title)
         case s: Primitive        => s.copy(title = Some(title))
         case s: Array            => s.copy(title = Some(title))
         case s: DocumentedEnum   => s.copy(title = Some(title))
@@ -531,7 +527,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Record[A] =
     new Record[A](
       record.ujsonSchema,
-      record.docs.withDescription(Some(description))
+      record.docs.withDescription(description)
     )
 
   def withDescriptionTagged[A](
@@ -540,7 +536,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Tagged[A] =
     new Tagged[A](
       tagged.ujsonSchema,
-      tagged.docs.withDescription(Some(description))
+      tagged.docs.withDescription(description)
     )
 
   def withDescriptionEnum[A](
@@ -558,8 +554,8 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): JsonSchema[A] = {
     def updatedDocs(djs: DocumentedJsonSchema): DocumentedJsonSchema =
       djs match {
-        case s: DocumentedRecord => s.withDescription(Some(description))
-        case s: DocumentedCoProd => s.withDescription(Some(description))
+        case s: DocumentedRecord => s.withDescription(description)
+        case s: DocumentedCoProd => s.withDescription(description)
         case s: Primitive        => s.copy(description = Some(description))
         case s: Array            => s.copy(description = Some(description))
         case s: DocumentedEnum   => s.copy(description = Some(description))

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -99,7 +99,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         def title: Option[String] = evaluatedDocs.title
 
         def withName(n: String): DocumentedRecord =
-          new Lazy(n, this)
+          new Lazy(n, docs)
         def withExample(e: => ujson.Value): DocumentedRecord =
           new Lazy(n, this) {
             override def example: Option[ujson.Value] = Some(e)
@@ -177,7 +177,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
         def title: Option[String] = evaluatedDocs.title
 
         def withName(n: String): DocumentedCoProd =
-          new Lazy(n, this)
+          new Lazy(n, docs)
         def withExample(e: => ujson.Value): DocumentedCoProd =
           new Lazy(n, this) {
             override def example: Option[ujson.Value] = Some(e)
@@ -191,7 +191,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
             override def description: Option[String] = Some(d)
           }
         def withDiscriminatorName(d: String): DocumentedCoProd =
-          new Lazy(n, null) {
+          new Lazy(n, this) {
             override def discriminatorName: String = d
           }
       }

--- a/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
@@ -130,6 +130,11 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
       val decoder = json => schema.decoder.decode(json)
       val encoder = value => schema.encoder.encode(value)
     }
+  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
+    new JsonSchema[A] {
+      val decoder = json => schema.decoder.decode(json)
+      val encoder = value => schema.encoder.encode(value)
+    }
 
   lazy val emptyRecord: Record[Unit] = new Record[Unit] {
 

--- a/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
@@ -119,22 +119,16 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
       val encoder = tpe.encoder
     }
 
-  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
+  override def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
     new JsonSchema[A] {
       val decoder = json => schema.decoder.decode(json)
       val encoder = value => schema.encoder.encode(value)
     }
 
+  def lazyRecord[A](schema: => Record[A], name: String): JsonSchema[A] =
+    lazySchema(name)(schema)
   def lazyTagged[A](schema: => Tagged[A], name: String): JsonSchema[A] =
-    new JsonSchema[A] {
-      val decoder = json => schema.decoder.decode(json)
-      val encoder = value => schema.encoder.encode(value)
-    }
-  def lazySchema[A](name: String)(schema: => JsonSchema[A]): JsonSchema[A] =
-    new JsonSchema[A] {
-      val decoder = json => schema.decoder.decode(json)
-      val encoder = value => schema.encoder.encode(value)
-    }
+    lazySchema(name)(schema)
 
   lazy val emptyRecord: Record[Unit] = new Record[Unit] {
 

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
@@ -386,6 +386,9 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
     }
   }
 
+  "Foo" in {
+    println(OpenApi.stringEncoder.encode(MyFixture.api))
+  }
 }
 
 trait Fixtures extends algebra.Endpoints with algebra.ChunkedEntities {
@@ -498,4 +501,52 @@ object Fixtures
       versionedResource
     )
 
+}
+
+trait MyFixture extends algebra.Endpoints with algebra.JsonEntitiesFromSchemas {
+  sealed trait Expression
+  object Expression {
+    case class Literal(value: Int) extends Expression
+    case class Add(x: Expression, y: Expression) extends Expression
+  }
+
+  implicit val expressionSchema: JsonSchema[Expression] =
+    lazySchema[Expression]("Expression") {
+      intJsonSchema
+        .orFallbackTo(field[Expression]("x") zip field[Expression]("y"))
+        .xmap[Expression] {
+          case Left(value)   => Expression.Literal(value)
+          case Right((x, y)) => Expression.Add(x, y)
+        } {
+          case Expression.Literal(value) => Left(value)
+          case Expression.Add(x, y)      => Right((x, y))
+        }
+    }
+
+  val eval = endpoint(
+    post(path / "eval", jsonRequest[Expression]),
+    ok(jsonResponse[Int])
+  )
+
+  case class A(b: Option[B])
+  case class B(a: Option[A])
+  implicit val aSchema: JsonSchema[A] = lazySchema("A") {
+    optField[B]("b").xmap(A.apply)(_.b)
+  }
+  implicit val bSchema: JsonSchema[B] = lazySchema("B") {
+    optField[A]("a").xmap(B.apply)(_.a)
+  }
+
+  val a = endpoint(
+    post(path / "a", jsonRequest[A]),
+    ok(jsonResponse[Int])
+  )
+  val b = endpoint(
+    post(path / "b", jsonRequest[B]),
+    ok(jsonResponse[Int])
+  )
+}
+
+object MyFixture extends MyFixture with Endpoints with JsonEntitiesFromSchemas {
+  val api = openApi(Info("My API", "1.0.0"))(eval, a, b)
 }

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
@@ -143,6 +143,83 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
     Fixtures.toSchema(Fixtures.recursiveSchema.docs) shouldBe expectedSchema
   }
 
+  "Recursive expression" in {
+    val expectedSchema =
+      Schema.Reference(
+        "Expression",
+        Some(
+          Schema.OneOf(
+            Schema.EnumeratedAlternatives(
+              Schema.Primitive("integer", Some("int32"), None, None, None) ::
+                Schema.Object(
+                  Schema.Property(
+                    "x",
+                    Schema.Reference("Expression", None, None),
+                    isRequired = true,
+                    description = None
+                  ) :: Schema.Property(
+                    "y",
+                    Schema.Reference("Expression", None, None),
+                    isRequired = true,
+                    description = None
+                  ) :: Nil,
+                  additionalProperties = None,
+                  description = None,
+                  example = None,
+                  title = None
+                ) :: Nil
+            ),
+            None,
+            None,
+            None
+          )
+        ),
+        None
+      )
+    Fixtures.toSchema(Fixtures.expressionSchema.docs) shouldBe expectedSchema
+  }
+  "Mutually recursive types" in {
+    Fixtures.toSchema(Fixtures.mutualRecursiveA.docs) shouldBe Schema.Reference(
+      "MutualRecursiveA",
+      Some(
+        Schema.Object(
+          Schema.Property(
+            "b",
+            Schema.Reference(
+              "MutualRecursiveB",
+              Some(
+                Schema.Object(
+                  Schema.Property(
+                    "a",
+                    Schema.Reference(
+                      "MutualRecursiveA",
+                      None,
+                      None
+                    ),
+                    isRequired = false,
+                    description = None
+                  ) :: Nil,
+                  additionalProperties = None,
+                  description = None,
+                  example = None,
+                  title = None
+                )
+              ),
+              None
+            ),
+            isRequired = false,
+            description = None
+          ) :: Nil,
+          additionalProperties = None,
+          description = None,
+          example = None,
+          title = None
+        )
+      ),
+      None
+    )
+  }
+
   "Refining JSON schemas preserves documentation" should {
     "JsonSchema" in {
       val expectedSchema = Fixtures.intJsonSchema.docs

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
@@ -17,9 +17,9 @@ class JsonSchemasTest extends AnyFreeSpec {
           "s",
           DocumentedJsonSchemas.defaultStringJsonSchema.docs,
           isOptional = false,
-          documentation = None,
+          documentation = None
         ) :: Nil
-      ),
+      )
     ) ::
       (
         "Baz",
@@ -28,9 +28,9 @@ class JsonSchemasTest extends AnyFreeSpec {
             "i",
             DocumentedJsonSchemas.intJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) :: Nil
-        ),
+        )
       ) ::
       ("Bax", DocumentedRecord(Nil)) ::
       ("Qux", DocumentedRecord(Nil)) ::
@@ -41,9 +41,9 @@ class JsonSchemasTest extends AnyFreeSpec {
             "b",
             DocumentedJsonSchemas.byteJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) :: Nil
-        ),
+        )
       ) ::
       Nil
   )
@@ -55,13 +55,13 @@ class JsonSchemasTest extends AnyFreeSpec {
           "name",
           DocumentedJsonSchemas.defaultStringJsonSchema.docs,
           isOptional = false,
-          documentation = Some("Name of the user"),
+          documentation = Some("Name of the user")
         ) ::
           Field(
             "age",
             DocumentedJsonSchemas.intJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) ::
           Nil
       )
@@ -85,7 +85,7 @@ class JsonSchemasTest extends AnyFreeSpec {
       DocumentedEnum(
         DocumentedJsonSchemas.defaultStringJsonSchema.docs,
         ujson.Str("Red") :: ujson.Str("Blue") :: Nil,
-        Some("Color"),
+        Some("Color")
       )
     assert(DocumentedJsonSchemas.Enum.colorSchema.docs == expectedSchema)
   }
@@ -98,7 +98,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             "quux",
             DocumentedJsonSchemas.defaultStringJsonSchema.docs,
             isOptional = false,
-            documentation = None,
+            documentation = None
           ) :: Nil
         ),
         ujson.Obj("quux" -> ujson.Str("bar")) :: ujson.Obj(
@@ -106,7 +106,7 @@ class JsonSchemasTest extends AnyFreeSpec {
         ) :: Nil,
         None,
         None,
-        None,
+        None
       )
     assert(
       DocumentedJsonSchemas.NonStringEnum.enumSchema.docs == expectedSchema
@@ -121,7 +121,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             None,
             None,
             None,
-            None,
+            None
           ) =>
         assert(tpe.isInstanceOf[LazySchema])
       case _ =>
@@ -131,11 +131,74 @@ class JsonSchemasTest extends AnyFreeSpec {
     }
   }
 
+  "recursive expression" in {
+    DocumentedJsonSchemas.expressionSchema.docs match {
+      case r: RecursiveSchema =>
+        assert(r.name == "Expression")
+        assert(
+          r.value == OneOf(
+            List(
+              Primitive(
+                "integer",
+                Some("int32"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+              ),
+              DocumentedRecord(
+                List(
+                  Field("x", r, false, None),
+                  Field("y", r, false, None)
+                ),
+                None,
+                None,
+                None,
+                None,
+                None
+              )
+            ),
+            None,
+            None,
+            None
+          )
+        )
+      case _ =>
+        fail(
+          s"Unexpected type for 'expressionSchema': ${DocumentedJsonSchemas.expressionSchema.docs}"
+        )
+    }
+  }
+  "mutually recursive" in {
+    DocumentedJsonSchemas.mutualRecursiveA.docs match {
+      case r: RecursiveSchema =>
+        assert(r.name == "MutualRecursiveA")
+        assert(
+          r.value == DocumentedRecord(
+            List(Field("b", DocumentedJsonSchemas.mutualRecursiveB.docs, true, None)),
+            None,
+            None,
+            None,
+            None,
+            None
+          )
+        )
+      case _ =>
+        fail(
+          s"Unexpected type for 'mutualRecursiveA': ${DocumentedJsonSchemas.mutualRecursiveA.docs}"
+        )
+    }
+  }
+
   "maps" in {
     val expected = DocumentedRecord(
       Nil,
       Some(DocumentedJsonSchemas.intJsonSchema.docs),
-      None,
+      None
     )
     assert(DocumentedJsonSchemas.intDictionary.docs == expected)
   }
@@ -156,7 +219,7 @@ class JsonSchemasTest extends AnyFreeSpec {
       minimum = Some(0.0),
       maximum = Some(10.0),
       exclusiveMaximum = Some(true),
-      multipleOf = Some(2.0),
+      multipleOf = Some(2.0)
     )
 
     assert(DocumentedJsonSchemas.constraintNumericSchema.docs == expected)

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
@@ -133,7 +133,7 @@ class JsonSchemasTest extends AnyFreeSpec {
 
   "recursive expression" in {
     DocumentedJsonSchemas.expressionSchema.docs match {
-      case r: RecursiveSchema =>
+      case r: LazySchema =>
         assert(r.name == "Expression")
         assert(
           r.value == OneOf(
@@ -175,7 +175,7 @@ class JsonSchemasTest extends AnyFreeSpec {
   }
   "mutually recursive" in {
     DocumentedJsonSchemas.mutualRecursiveA.docs match {
-      case r: RecursiveSchema =>
+      case r: LazySchema =>
         assert(r.name == "MutualRecursiveA")
         assert(
           r.value == DocumentedRecord(

--- a/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasTest.scala
@@ -348,6 +348,23 @@ class JsonSchemasTest extends AnyFreeSpec {
       Recursive(Some(Recursive(Some(Recursive(None)))))
     )
   }
+  "recursive expression type" in {
+    checkRoundTrip(
+      expressionSchema,
+      ujson.Obj("x" -> ujson.Obj("x" -> ujson.Num(1), "y" -> ujson.Num(2)), "y" -> ujson.Num(3)),
+      Expression.Add(
+        Expression.Add(Expression.Literal(1), Expression.Literal(2)),
+        Expression.Literal(3)
+      )
+    )
+  }
+  "mutually recursive types" in {
+    checkRoundTrip(
+      mutualRecursiveA,
+      ujson.Obj("b" -> ujson.Obj("a" -> ujson.Obj())),
+      MutualRecursiveA(Some(MutualRecursiveB(Some(MutualRecursiveA(None)))))
+    )
+  }
 
   "refined JsonSchema" in {
     checkRoundTrip(

--- a/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasTest.scala
@@ -365,6 +365,28 @@ class JsonSchemasTest extends AnyFreeSpec {
       MutualRecursiveA(Some(MutualRecursiveB(Some(MutualRecursiveA(None)))))
     )
   }
+  "recursive tagged" in {
+    checkRoundTrip(
+      taggedRecursiveSchema,
+      ujson.Obj(
+        "kind" -> ujson.Str("A"),
+        "a" -> ujson.Str("foo"),
+        "next" -> ujson.Obj(
+          "kind" -> ujson.Str("B"),
+          "b" -> ujson.Num(42)
+        )
+      ),
+      JsonSchemasCodec.TaggedRecursiveA(
+        a = "foo",
+        next = Some(
+          JsonSchemasCodec.TaggedRecursiveB(
+            b = 42,
+            next = None
+          )
+        )
+      )
+    )
+  }
 
   "refined JsonSchema" in {
     checkRoundTrip(

--- a/play/build.sbt
+++ b/play/build.sbt
@@ -15,7 +15,7 @@ val `play-server` =
       `scala 2.12 to dotty`, // Note that we could support 2.11. Only our tests use circe (which has dropped 2.11)
       name := "play-server",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("com.typesafe.play" %% "play-netty-server" % playVersion).cross(CrossVersion.for3Use2_13),
         ("com.typesafe.play" %% "play-test" % playVersion % Test).cross(CrossVersion.for3Use2_13),
@@ -46,7 +46,7 @@ val `play-server-circe` =
       `scala 2.12 to dotty`,
       name := "play-server-circe",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies += ("io.circe" %% "circe-parser" % circeVersion).cross(CrossVersion.for3Use2_13)
     )
     .dependsOn(`play-server`, `algebra-circe-jvm`, `json-schema-circe-jvm`)
@@ -59,7 +59,7 @@ val `play-client` =
       `scala 2.12 to dotty`,
       name := "play-client",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("com.typesafe.play" %% "play-ahc-ws" % playVersion).cross(CrossVersion.for3Use2_13),
         // Override transitive dependencies of Play

--- a/scalaj/build.sbt
+++ b/scalaj/build.sbt
@@ -12,7 +12,7 @@ val `scalaj-client` =
       `scala 2.12 to 2.13`,
       name := "scalaj-client",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.scalaj" %% "scalaj-http" % "2.4.2"
       )

--- a/xhr/build.sbt
+++ b/xhr/build.sbt
@@ -10,7 +10,7 @@ val `xhr-client` =
       `scala 2.12 to 2.13`,
       name := "xhr-client",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies ++= Seq(
@@ -31,7 +31,7 @@ val `xhr-client-faithful` =
       `scala 2.12 to 2.13`,
       name := "xhr-client-faithful",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies += "org.julienrf" %%% "faithful" % "2.0.0"
@@ -48,7 +48,7 @@ val `xhr-client-circe` =
       `scala 2.12 to 2.13`,
       name := "xhr-client-circe",
       version := "2.0.0+n",
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.None,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies += "io.circe" %%% "circe-parser" % circeVersion,


### PR DESCRIPTION
Allow more general recursive schemas than `lazyRecord` or `lazyTagged`.
For instance schema for an expression language like:

```json
  {"op": "add", "x": 1, "y": {"op": "add", "x": 2, "y": 3}}
```

See discussion at https://github.com/endpoints4s/endpoints4s/issues/834