### PR TITLE
Update http4s to 0.23.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ node_modules/
 .bloop/
 .vscode/
 .bsp/
-
+metals.sbt
 project/metals.sbt
 
 #direnv, niv and lorri

--- a/documentation/examples/basic/http4s-server/src/main/scala/sample/Server.scala
+++ b/documentation/examples/basic/http4s-server/src/main/scala/sample/Server.scala
@@ -1,7 +1,7 @@
 package sample
 
 import cats.effect._
-import org.http4s.server.blaze._
+import org.http4s.blaze.server._
 import org.http4s.implicits._
 
 import scala.concurrent.ExecutionContext

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -13,7 +13,7 @@ val `http4s-server` =
       `scala 2.12 to dotty`,
       name := "http4s-server",
       versionPolicyIntention := Compatibility.BinaryCompatible,
-      version := "6.0.0+n",
+      version := "7.0.0+n",
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-core" % http4sVersion).cross(CrossVersion.for3Use2_13),
         ("org.http4s" %% "http4s-dsl" % http4sVersion).cross(CrossVersion.for3Use2_13),
@@ -36,7 +36,7 @@ val `http4s-client` =
       `scala 2.12 to dotty`,
       name := "http4s-client",
       versionPolicyIntention := Compatibility.BinaryCompatible,
-      version := "4.0.0+n",
+      version := "5.0.0+n",
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-client" % http4sVersion).cross(CrossVersion.for3Use2_13),
         ("org.http4s" %% "http4s-async-http-client" % http4sVersion % Test).cross(CrossVersion.for3Use2_13)

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -12,8 +12,8 @@ val `http4s-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-server",
-      versionPolicyIntention := Compatibility.BinaryCompatible,
-      version := "7.0.0+n",
+      versionPolicyIntention := Compatibility.None,
+      version := "6.0.0+n",
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-core" % http4sVersion).cross(CrossVersion.for3Use2_13),
         ("org.http4s" %% "http4s-dsl" % http4sVersion).cross(CrossVersion.for3Use2_13),
@@ -35,8 +35,8 @@ val `http4s-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-client",
-      versionPolicyIntention := Compatibility.BinaryCompatible,
-      version := "5.0.0+n",
+      versionPolicyIntention := Compatibility.None,
+      version := "4.0.0+n",
       libraryDependencies ++= Seq(
         ("org.http4s" %% "http4s-client" % http4sVersion).cross(CrossVersion.for3Use2_13),
         ("org.http4s" %% "http4s-async-http-client" % http4sVersion % Test).cross(CrossVersion.for3Use2_13)

--- a/http4s/client/src/main/scala/endpoints4s/http4s/client/Endpoints.scala
+++ b/http4s/client/src/main/scala/endpoints4s/http4s/client/Endpoints.scala
@@ -136,7 +136,13 @@ trait EndpointsWithCustomErrors
     effect.map(effect.fromEither(url.encodeUrl(urlP)))(uri =>
       entity(
         bodyP,
-        headers(headersP, Http4sRequest(method, host.withPath(host.path.concat(uri.path))))
+        headers(
+          headersP,
+          Http4sRequest(
+            method,
+            host.withPath(Uri.Path.unsafeFromString(host.path.renderString + uri.renderString))
+          )
+        )
       )
     )
   }
@@ -168,8 +174,6 @@ trait EndpointsWithCustomErrors
     }
 
   override def emptyResponse: ResponseEntity[Unit] = _ => ().pure[Effect]
-
-    
 
   override def textResponse: ResponseEntity[String] = _.as[String]
 

--- a/http4s/client/src/main/scala/endpoints4s/http4s/client/Endpoints.scala
+++ b/http4s/client/src/main/scala/endpoints4s/http4s/client/Endpoints.scala
@@ -1,6 +1,6 @@
 package endpoints4s.http4s.client
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.implicits._
 import endpoints4s.algebra
 import endpoints4s.InvariantFunctor
@@ -9,22 +9,21 @@ import endpoints4s.Semigroupal
 import endpoints4s.PartialInvariantFunctor
 import endpoints4s.Invalid
 import org.http4s.{Request => Http4sRequest, Response => Http4sResponse}
-import org.http4s.Header
 import org.http4s.client.Client
 import org.http4s.Headers
 import endpoints4s.Validated
 import endpoints4s.Valid
-import org.http4s.util.CaseInsensitiveString
+import org.typelevel.ci._
 import cats.data.Kleisli
 import org.http4s.Status
 import org.http4s.Uri
 
-class Endpoints[F[_]: Sync](val host: Uri, val client: Client[F])
+class Endpoints[F[_]: Concurrent](val host: Uri, val client: Client[F])
     extends algebra.Endpoints
     with EndpointsWithCustomErrors
     with BuiltInErrors {
   type Effect[A] = F[A]
-  override def effect: Sync[Effect] = Sync[F]
+  override def effect: Concurrent[Effect] = Concurrent[F]
 }
 
 trait EndpointsWithCustomErrors
@@ -34,7 +33,7 @@ trait EndpointsWithCustomErrors
     with StatusCodes {
 
   type Effect[A]
-  implicit def effect: Sync[Effect]
+  implicit def effect: Concurrent[Effect]
 
   def host: Uri
   def client: Client[Effect]
@@ -47,7 +46,7 @@ trait EndpointsWithCustomErrors
       name: String,
       docs: Option[String]
   ): RequestHeaders[String] =
-    (value, req) => req.putHeaders(Header(name, value))
+    (value, req) => req.putHeaders((name, value))
 
   override def optRequestHeader(
       name: String,
@@ -55,7 +54,7 @@ trait EndpointsWithCustomErrors
   ): RequestHeaders[Option[String]] =
     (value, req) =>
       value match {
-        case Some(v) => req.putHeaders(Header(name, v))
+        case Some(v) => req.putHeaders((name, v))
         case None    => req
       }
 
@@ -137,7 +136,7 @@ trait EndpointsWithCustomErrors
     effect.map(effect.fromEither(url.encodeUrl(urlP)))(uri =>
       entity(
         bodyP,
-        headers(headersP, Http4sRequest(method, host.withPath(host.path + uri)))
+        headers(headersP, Http4sRequest(method, host.withPath(host.path.concat(uri.path))))
       )
     )
   }
@@ -169,6 +168,8 @@ trait EndpointsWithCustomErrors
     }
 
   override def emptyResponse: ResponseEntity[Unit] = _ => ().pure[Effect]
+
+    
 
   override def textResponse: ResponseEntity[String] = _.as[String]
 
@@ -204,8 +205,8 @@ trait EndpointsWithCustomErrors
       docs: Option[String]
   ): ResponseHeaders[String] =
     hs =>
-      hs.get(CaseInsensitiveString(name)) match {
-        case Some(h) => Valid(h.value)
+      hs.get(CIString(name)) match {
+        case Some(h) => Valid(h.head.value)
         case None    => Invalid(s"Header '$name' not found")
       }
 
@@ -213,7 +214,7 @@ trait EndpointsWithCustomErrors
       name: String,
       docs: Option[String]
   ): ResponseHeaders[Option[String]] =
-    hs => Valid(hs.get(CaseInsensitiveString(name)).map(_.value))
+    hs => Valid(hs.get(CIString(name)).map(_.head.value))
 
   override def response[A, B, R](
       statusCode: StatusCode,

--- a/http4s/client/src/main/scala/endpoints4s/http4s/client/Urls.scala
+++ b/http4s/client/src/main/scala/endpoints4s/http4s/client/Urls.scala
@@ -82,7 +82,7 @@ trait Urls extends endpoints4s.algebra.Urls with StatusCodes {
     }
 
   override def stringSegment: Segment[String] =
-    s => Uri.pathEncode(s)
+    s => Uri.Path.unsafeFromString(Uri.pathEncode(s))
 
   trait Path[A] extends Url[A] {
     final def encodeUrl(value: A): ParseResult[Uri] =
@@ -104,7 +104,7 @@ trait Urls extends endpoints4s.algebra.Urls with StatusCodes {
 
   def segment[A](name: String, docs: Documentation)(implicit
       s: Segment[A]
-  ): Path[A] = a => s.encode(a) :: Nil
+  ): Path[A] = a => s.encode(a).renderString :: Nil
 
   def remainingSegments(name: String, docs: Documentation): Path[String] =
     _ :: Nil

--- a/http4s/client/src/test/scala/endpoints4s/http4s/client/Http4sClientEndpointsJsonSchemaTest.scala
+++ b/http4s/client/src/test/scala/endpoints4s/http4s/client/Http4sClientEndpointsJsonSchemaTest.scala
@@ -3,17 +3,16 @@ package endpoints4s.http4s.client
 import endpoints4s.algebra
 import endpoints4s.algebra.client
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import org.http4s.client.Client
 import cats.effect.IO
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.global
-import org.http4s.client.asynchttpclient.AsyncHttpClient
-import cats.effect.ContextShift
+import _root_.org.http4s.asynchttpclient.client.AsyncHttpClient
+import cats.effect.unsafe.implicits.global
 import endpoints4s.algebra.circe
 import org.http4s.Uri
 
-class TestJsonSchemaClient[F[_]: Sync](host: Uri, client: Client[F])
+class TestJsonSchemaClient[F[_]: Concurrent](host: Uri, client: Client[F])
     extends Endpoints[F](host, client)
     with BasicAuthentication
     with JsonEntitiesFromCodecs
@@ -30,7 +29,6 @@ class Http4sClientEndpointsJsonSchemaTest
     with client.JsonFromCodecTestSuite[TestJsonSchemaClient[IO]]
     with client.SumTypedEntitiesTestSuite[TestJsonSchemaClient[IO]] {
 
-  implicit val ctx: ContextShift[IO] = IO.contextShift(global)
 
   val (ahc, shutdown) =
     AsyncHttpClient.allocate[IO]().unsafeRunSync()

--- a/http4s/client/src/test/scala/endpoints4s/http4s/client/Http4sClientEndpointsJsonSchemaTest.scala
+++ b/http4s/client/src/test/scala/endpoints4s/http4s/client/Http4sClientEndpointsJsonSchemaTest.scala
@@ -29,7 +29,6 @@ class Http4sClientEndpointsJsonSchemaTest
     with client.JsonFromCodecTestSuite[TestJsonSchemaClient[IO]]
     with client.SumTypedEntitiesTestSuite[TestJsonSchemaClient[IO]] {
 
-
   val (ahc, shutdown) =
     AsyncHttpClient.allocate[IO]().unsafeRunSync()
 

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
@@ -12,7 +12,7 @@ import cats.effect.kernel.Sync
 trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
   val DefaultBufferSize = 10240
 
-  implicit def EffectSync: Sync[Effect] 
+  implicit def EffectSync: Sync[Effect]
 
   // Digests are unsupported.
   def digests: Map[String, String] = Map.empty
@@ -80,7 +80,7 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
         if (isGzipped) Some(`Content-Encoding`(ContentCoding.gzip)) else None
       val contentLengthHeader: Header.ToRaw =
         `Content-Length`.fromLong(length) match {
-          case Left(_) => `Transfer-Encoding`(TransferCoding.chunked)
+          case Left(_)   => `Transfer-Encoding`(TransferCoding.chunked)
           case Right(cl) => cl
         }
 

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Assets.scala
@@ -2,15 +2,17 @@ package endpoints4s.http4s.server
 
 import java.net.URL
 
-import cats.effect.{Blocker, ContextShift}
 import endpoints4s.algebra.Documentation
 import endpoints4s.{Valid, algebra}
 import fs2.io._
 import org.http4s.headers._
 import org.http4s._
+import cats.effect.kernel.Sync
 
 trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
   val DefaultBufferSize = 10240
+
+  implicit def EffectSync: Sync[Effect] 
 
   // Digests are unsupported.
   def digests: Map[String, String] = Map.empty
@@ -63,21 +65,24 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
   }
 
   private val gzipSupport: RequestHeaders[Boolean] =
-    headers => Valid(headers.get(`Accept-Encoding`).exists(_.satisfiedBy(ContentCoding.gzip)))
+    headers => Valid(headers.get[`Accept-Encoding`].exists(_.satisfiedBy(ContentCoding.gzip)))
 
   private val ifModifiedSince: RequestHeaders[Option[HttpDate]] =
-    headers => Valid(headers.get(`If-Modified-Since`).map(_.date))
+    headers => Valid(headers.get[`If-Modified-Since`].map(_.date))
 
   private val assetResponse: Response[AssetResponse] = {
     case AssetResponse.NotFound                    => Response(NotFound)
     case AssetResponse.Found(_, _, _, _, _, false) => Response(NotModified)
     case AssetResponse.Found(data, length, lastModified, mediaType, isGzipped, true) =>
-      val lastModifiedHeader = lastModified.map(`Last-Modified`(_))
-      val contentTypeHeader = mediaType.map(`Content-Type`(_))
-      val contentCodingHeader =
+      val lastModifiedHeader: Option[Header.ToRaw] = lastModified.map(`Last-Modified`(_))
+      val contentTypeHeader: Option[Header.ToRaw] = mediaType.map(`Content-Type`(_))
+      val contentCodingHeader: Option[Header.ToRaw] =
         if (isGzipped) Some(`Content-Encoding`(ContentCoding.gzip)) else None
-      val contentLengthHeader =
-        `Content-Length`.fromLong(length).getOrElse(`Transfer-Encoding`(TransferCoding.chunked))
+      val contentLengthHeader: Header.ToRaw =
+        `Content-Length`.fromLong(length) match {
+          case Left(_) => `Transfer-Encoding`(TransferCoding.chunked)
+          case Right(cl) => cl
+        }
 
       val headers = Headers(
         contentLengthHeader :: List(
@@ -142,10 +147,7 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
     * @return A function that, given an [[AssetRequest]], builds an [[AssetResponse]] by
     *         looking for the requested asset in the classpath resources.
     */
-  def assetsResources(
-      blocker: Blocker,
-      pathPrefix: Option[String] = None
-  )(implicit cs: ContextShift[Effect]): AssetRequest => AssetResponse =
+  def assetsResources(pathPrefix: Option[String] = None): AssetRequest => AssetResponse =
     assetRequest =>
       toResourceUrl(pathPrefix, assetRequest)
         .map { case (url, isGzipped) =>
@@ -157,7 +159,7 @@ trait Assets extends algebra.Assets with EndpointsWithCustomErrors {
             ifModifiedSinceSeconds.map(_ < lastModifiedSeconds).getOrElse(true)
 
           foundAssetResponse(
-            content = readInputStream(Effect.delay(url.openStream), DefaultBufferSize, blocker),
+            content = readInputStream(EffectSync.blocking(url.openStream), DefaultBufferSize),
             contentLength = urlConnection.getContentLengthLong,
             fileName = assetRequest.assetPath.name,
             isGzipped = isGzipped,

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/BasicAuthentication.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/BasicAuthentication.scala
@@ -27,7 +27,7 @@ trait BasicAuthentication
     headers =>
       Valid(
         headers
-          .get(Authorization)
+          .get[Authorization]
           .flatMap { authHeader =>
             authHeader.credentials match {
               case BasicCredentials(username, password) =>

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/BuiltInErrors.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/BuiltInErrors.scala
@@ -17,7 +17,7 @@ trait BuiltInErrors extends algebra.BuiltInErrors {
     val hdr = `Content-Type`(MediaType.application.json)
     EntityEncoder.simple(hdr) { invalid =>
       val s = endpoints4s.ujson.codecs.invalidCodec.encode(invalid)
-      Chunk.bytes(s.getBytes(StandardCharsets.UTF_8))
+      Chunk.array(s.getBytes(StandardCharsets.UTF_8))
     }
   }
 

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -93,6 +93,6 @@ private object JsonEntities {
       endpoints: EndpointsWithCustomErrors
   )(encoder: Encoder[A, String]): endpoints.ResponseEntity[A] =
     EntityEncoder[endpoints.Effect, Chunk[Byte]]
-      .contramap[A](value => Chunk.bytes(encoder.encode(value).getBytes()))
+      .contramap[A](value => Chunk.array(encoder.encode(value).getBytes()))
       .withContentType(`Content-Type`(MediaType.application.json))
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/Urls.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/Urls.scala
@@ -220,10 +220,10 @@ trait Urls extends algebra.Urls with StatusCodes {
       uri: http4s.Uri
   ): Option[Validated[A]] = {
     val segments =
-      uri.path
+      uri.path.renderString
         .split("/")
         .map(URLDecoder.decode(_, utf8Name))
-        .toList ++ { if (uri.path.endsWith("/")) List("") else Nil }
+        .toList ++ { if (uri.path.renderString.endsWith("/")) List("") else Nil }
 
     path.decode(if (segments.isEmpty) List("") else segments).flatMap {
       case (validated, Nil) => Some(validated)

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/EndpointsTestApi.scala
@@ -1,6 +1,6 @@
 package endpoints4s.http4s.server
 
-import cats.effect.IO
+import cats.effect.{IO, Sync}
 import endpoints4s.algebra
 
 class EndpointsTestApi
@@ -16,6 +16,8 @@ class EndpointsTestApi
     with algebra.SumTypedEntitiesTestApi {
 
   implicit def userCodec = userJsonSchema
+
+  def EffectSync: Sync[Effect] = Sync[IO]
 
   type AssetContent = fs2.Stream[Effect, Byte]
 

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/ServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/ServerInterpreterTest.scala
@@ -2,7 +2,7 @@ package endpoints4s.http4s.server
 
 import java.net.ServerSocket
 
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
 import endpoints4s.{Invalid, Valid}
 import endpoints4s.algebra.server.{
   BasicAuthenticationTestSuite,
@@ -14,12 +14,12 @@ import endpoints4s.algebra.server.{
 }
 import org.http4s.server.Router
 import org.http4s.{HttpRoutes, Uri}
-import org.http4s.server.blaze.BlazeServerBuilder
+import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 
 import scala.concurrent.ExecutionContext
 import endpoints4s.algebra.server.AssetsTestSuite
-import cats.effect.Blocker
+import cats.effect.unsafe.implicits.global
 
 class ServerInterpreterTest
     extends EndpointsTestSuite[EndpointsTestApi]
@@ -29,9 +29,6 @@ class ServerInterpreterTest
     with SumTypedEntitiesTestSuite[EndpointsTestApi]
     with AssetsTestSuite[EndpointsTestApi]
     with AssetsResourcesTest {
-
-  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
-  implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   val serverApi = new EndpointsTestApi
 
@@ -66,9 +63,7 @@ class ServerInterpreterTest
   }
 
   def assetsResources(pathPrefix: Option[String]) =
-    Blocker[IO]
-      .use(blocker => serverApi.Effect.point(serverApi.assetsResources(blocker, pathPrefix)))
-      .unsafeRunSync()
+    serverApi.assetsResources(pathPrefix)
 
   def serveAssetsEndpoint(
       endpoint: serverApi.Endpoint[

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -103,7 +103,7 @@ object EndpointsSettings {
   val sttpVersion = "3.3.13"
   val akkaActorVersion = "2.6.15"
   val akkaHttpVersion = "10.2.5"
-  val http4sVersion = "0.21.25"
+  val http4sVersion = "0.23.0"
   val ujsonVersion = "1.4.0"
 
   val scalaTestVersion = "3.2.9"


### PR DESCRIPTION
Replaces #869. Server currently passes all tests, but there's some errors in the client code, that I assume is due to Uri path issues.