### PR TITLE
OpenAPI: document default field values

### DIFF
--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -342,7 +342,7 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     *
     * @group operations
     */
-  final def optFieldWithDefault[A: JsonSchema](
+  def optFieldWithDefault[A: JsonSchema](
       name: String,
       defaultValue: A,
       docs: Option[String] = None

--- a/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasFixtures.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasFixtures.scala
@@ -23,6 +23,11 @@ trait JsonSchemasFixtures extends JsonSchemas {
         field[String]("name", Some("Name of the user")) zip
         field[Int]("age")
     ).xmap((User.apply _).tupled)(user => (user.name, user.age))
+
+    val schemaWithDefault: JsonSchema[User] = (
+      field[String]("name", Some("Name of the user")) zip
+        optFieldWithDefault[Int]("age", 42)
+    ).xmap((User.apply _).tupled)(user => (user.name, user.age))
   }
 
   sealed trait Foo

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/JsonSchemas.scala
@@ -1,6 +1,13 @@
 package endpoints4s.openapi
 
-import endpoints4s.{NumericConstraints, PartialInvariantFunctor, Tupler, Validated, algebra}
+import endpoints4s.{
+  Hashing,
+  NumericConstraints,
+  PartialInvariantFunctor,
+  Tupler,
+  Validated,
+  algebra
+}
 import endpoints4s.algebra.Documentation
 import endpoints4s.openapi.model.Schema
 import endpoints4s.openapi.model.Schema.{DiscriminatedAlternatives, EnumeratedAlternatives}
@@ -127,12 +134,104 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
 
     }
 
-    case class Field(
-        name: String,
-        tpe: DocumentedJsonSchema,
-        isOptional: Boolean,
-        documentation: Option[String]
-    )
+    @deprecatedInheritance
+    class Field private (
+        val name: String,
+        val tpe: DocumentedJsonSchema,
+        val isOptional: Boolean,
+        val default: Option[ujson.Value],
+        val documentation: Option[String]
+    ) extends Serializable
+        with Product
+        with Equals {
+
+      @deprecated("`Field` is no longer a `case class` and won't implement `Equals`", "3.1.0")
+      override def canEqual(other: Any): Boolean = other.isInstanceOf[Field]
+      @deprecated("`Field` is no longer a `case class` and won't implement `Product`", "3.1.0")
+      override def productArity: Int = 5
+      @deprecated("`Field` is no longer a `case class` and won't implement `Product`", "3.1.0")
+      override def productElement(idx: Int): Any = idx match {
+        case 0 => name
+        case 1 => tpe
+        case 2 => isOptional
+        case 3 => default
+        case 4 => documentation
+        case _ => throw new IndexOutOfBoundsException(idx.toString)
+      }
+      override def toString: String = s"Field($name,$tpe,$isOptional,$default,$documentation)"
+      override def hashCode: Int = Hashing.hash(name, tpe, isOptional, default, documentation)
+      override def equals(other: Any): Boolean = other match {
+        case field: Field =>
+          name == field.name && tpe == field.tpe && isOptional == field.isOptional &&
+            default == field.default && documentation == field.documentation
+        case _ => false
+      }
+
+      @deprecated("Use the Field apply method instead", "3.1.0")
+      def this(
+          name: String,
+          tpe: DocumentedJsonSchema,
+          isOptional: Boolean,
+          documentation: Option[String]
+      ) = this(name, tpe, isOptional, None, documentation)
+
+      @deprecated("Use `withName`, `withTpe`, etc. instead of `copy`", "3.1.0")
+      def copy(
+          name: String = name,
+          tpe: DocumentedJsonSchema = tpe,
+          isOptional: Boolean = isOptional,
+          documentation: Option[String] = documentation
+      ): Field =
+        new Field(name, tpe, isOptional, default, documentation)
+
+      def withName(name: String): Field =
+        new Field(name, tpe, isOptional, default, documentation)
+
+      def withTpe(tpe: DocumentedJsonSchema): Field =
+        new Field(name, tpe, isOptional, default, documentation)
+
+      def withIsOptional(isOptional: Boolean): Field =
+        new Field(name, tpe, isOptional, default, documentation)
+
+      def withDocumentation(documentation: Option[String]): Field =
+        new Field(name, tpe, isOptional, default, documentation)
+    }
+
+    object Field
+        extends runtime.AbstractFunction4[String, DocumentedJsonSchema, Boolean, Option[
+          String
+        ], Field] {
+
+      @deprecated(
+        "The Field apply method now takes an additional parameter 'default'",
+        "3.1.0"
+      )
+      def apply(
+          name: String,
+          tpe: DocumentedJsonSchema,
+          isOptional: Boolean,
+          documentation: Option[String]
+      ): Field = new Field(name, tpe, isOptional, None, documentation)
+
+      def apply(
+          name: String,
+          tpe: DocumentedJsonSchema,
+          isOptional: Boolean,
+          defaultValue: Option[ujson.Value],
+          documentation: Option[String]
+      ): Field = new Field(name, tpe, isOptional, defaultValue, documentation)
+
+      @deprecated("Use field extractors instead of unapply", "3.1.0")
+      def unapply(field: Field): Option[(String, DocumentedJsonSchema, Boolean, Option[String])] =
+        Some(
+          (
+            field.name,
+            field.tpe,
+            field.isOptional,
+            field.documentation
+          )
+        )
+    }
 
     sealed abstract class DocumentedCoProd extends DocumentedJsonSchema {
       def alternatives: List[(String, DocumentedRecord)]
@@ -380,7 +479,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Record[A] =
     new Record(
       ujsonSchemas.field(name, docs)(tpe.ujsonSchema),
-      DocumentedRecord(Field(name, tpe.docs, isOptional = false, docs) :: Nil)
+      DocumentedRecord(Field(name, tpe.docs, isOptional = false, defaultValue = None, docs) :: Nil)
     )
 
   def optField[A](name: String, docs: Documentation)(implicit
@@ -388,8 +487,22 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
   ): Record[Option[A]] =
     new Record(
       ujsonSchemas.optField(name, docs)(tpe.ujsonSchema),
-      DocumentedRecord(Field(name, tpe.docs, isOptional = true, docs) :: Nil)
+      DocumentedRecord(Field(name, tpe.docs, isOptional = true, defaultValue = None, docs) :: Nil)
     )
+
+  override def optFieldWithDefault[A](
+      name: String,
+      defaultValue: A,
+      docs: Option[String] = None
+  )(implicit
+      tpe: JsonSchema[A]
+  ): Record[A] = {
+    val defValue = Some(tpe.ujsonSchema.encoder.encode(defaultValue))
+    new Record(
+      ujsonSchemas.optFieldWithDefault(name, defaultValue, docs)(tpe.ujsonSchema),
+      DocumentedRecord(Field(name, tpe.docs, isOptional = true, defValue, docs) :: Nil)
+    )
+  }
 
   def taggedRecord[A](recordA: Record[A], tag: String): Tagged[A] =
     new Tagged(
@@ -1031,6 +1144,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
           f.name,
           toSchema(f.tpe, None, referencedSchemas),
           !f.isOptional,
+          f.default,
           f.documentation
         )
       )
@@ -1059,6 +1173,7 @@ trait JsonSchemas extends algebra.JsonSchemas with TuplesSchemas {
               None
             ),
           isRequired = true,
+          defaultValue = None,
           description = None
         )
 

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/DefaultsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/DefaultsTest.scala
@@ -1,0 +1,34 @@
+package endpoints4s.openapi
+
+import endpoints4s.algebra
+import endpoints4s.openapi.model.OpenApi
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DefaultsTest extends AnyWordSpec with Matchers {
+
+  "Schemas" should {
+    "Document default values for fields" in new Fixtures {
+      val expected =
+        ujson.Obj(
+          "type" -> ujson.Str("object"),
+          "properties" -> ujson.Obj(
+            "name" -> ujson.Obj(
+              "type" -> ujson.Str("string"),
+              "description" -> ujson.Str("Name of the user")
+            ),
+            "age" -> ujson.Obj(
+              "type" -> ujson.Str("integer"),
+              "format" -> ujson.Str("int32"),
+              "default" -> ujson.Num(42)
+            )
+          ),
+          "required" -> ujson.Arr(ujson.Str("name"))
+        )
+      assert(OpenApi.schemaJson(toSchema(User.schemaWithDefault.docs)) == expected)
+    }
+  }
+
+  trait Fixtures extends algebra.JsonSchemasFixtures with JsonSchemas
+
+}

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/EndpointsTest.scala
@@ -71,12 +71,14 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
             "name",
             Schema.Primitive("string", None, None, None, None),
             isRequired = true,
+            defaultValue = None,
             description = Some("Name of the user")
           ) ::
             Schema.Property(
               "age",
               Schema.Primitive("integer", Some("int32"), None, None, None),
               isRequired = true,
+              defaultValue = None,
               description = None
             ) ::
             Nil,
@@ -117,6 +119,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
               "next",
               Schema.Reference("Rec", None, None),
               isRequired = false,
+              defaultValue = None,
               description = None
             ) :: Nil,
             additionalProperties = None,
@@ -143,11 +146,13 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
                     "x",
                     Schema.Reference("Expression", None, None),
                     isRequired = true,
+                    defaultValue = None,
                     description = None
                   ) :: Schema.Property(
                     "y",
                     Schema.Reference("Expression", None, None),
                     isRequired = true,
+                    defaultValue = None,
                     description = None
                   ) :: Nil,
                   additionalProperties = None,
@@ -184,6 +189,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
                       None
                     ),
                     isRequired = false,
+                    defaultValue = None,
                     description = None
                   ) :: Nil,
                   additionalProperties = None,
@@ -195,6 +201,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
               None
             ),
             isRequired = false,
+            defaultValue = None,
             description = None
           ) :: Nil,
           additionalProperties = None,
@@ -217,12 +224,14 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
         None
       ),
       isRequired = true,
+      defaultValue = None,
       description = None
     )
     val nextSchema = Schema.Property(
       "next",
       Schema.Reference("TaggedRec", None, None),
       isRequired = false,
+      defaultValue = None,
       description = None
     )
     Fixtures.toSchema(Fixtures.taggedRecursiveSchema.docs) shouldBe Schema.Reference(
@@ -238,6 +247,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
                     "a",
                     Schema.Primitive("string", None, None, None, None),
                     isRequired = true,
+                    defaultValue = None,
                     description = None
                   )
                   :: nextSchema
@@ -254,6 +264,7 @@ class EndpointsTest extends AnyWordSpec with Matchers with OptionValues {
                     "b",
                     Schema.Primitive("integer", Some("int32"), None, None, None),
                     isRequired = true,
+                    defaultValue = None,
                     description = None
                   )
                   :: nextSchema

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
@@ -17,6 +17,7 @@ class JsonSchemasTest extends AnyFreeSpec {
           "s",
           DocumentedJsonSchemas.defaultStringJsonSchema.docs,
           isOptional = false,
+          defaultValue = None,
           documentation = None
         ) :: Nil
       )
@@ -28,6 +29,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             "i",
             DocumentedJsonSchemas.intJsonSchema.docs,
             isOptional = false,
+            defaultValue = None,
             documentation = None
           ) :: Nil
         )
@@ -41,6 +43,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             "b",
             DocumentedJsonSchemas.byteJsonSchema.docs,
             isOptional = false,
+            defaultValue = None,
             documentation = None
           ) :: Nil
         )
@@ -55,12 +58,14 @@ class JsonSchemasTest extends AnyFreeSpec {
           "name",
           DocumentedJsonSchemas.defaultStringJsonSchema.docs,
           isOptional = false,
+          defaultValue = None,
           documentation = Some("Name of the user")
         ) ::
           Field(
             "age",
             DocumentedJsonSchemas.intJsonSchema.docs,
             isOptional = false,
+            defaultValue = None,
             documentation = None
           ) ::
           Nil
@@ -98,6 +103,7 @@ class JsonSchemasTest extends AnyFreeSpec {
             "quux",
             DocumentedJsonSchemas.defaultStringJsonSchema.docs,
             isOptional = false,
+            defaultValue = None,
             documentation = None
           ) :: Nil
         ),
@@ -125,8 +131,12 @@ class JsonSchemasTest extends AnyFreeSpec {
         assert(r.example == Some(ujson.Obj()))
         assert(r.title == Some("Rec title"))
         r.fields match {
-          case List(Field("next", tpe, true, None)) =>
-            assert(tpe eq r)
+          case List(field) =>
+            assert(field.name == "next")
+            assert(field.tpe eq r)
+            assert(field.isOptional == true)
+            assert(field.default == None)
+            assert(field.documentation == None)
           case _ => badSchema
 
         }
@@ -155,8 +165,8 @@ class JsonSchemasTest extends AnyFreeSpec {
               ),
               DocumentedRecord(
                 List(
-                  Field("x", r, false, None),
-                  Field("y", r, false, None)
+                  Field("x", r, false, None, None),
+                  Field("y", r, false, None, None)
                 ),
                 None,
                 None,
@@ -182,7 +192,7 @@ class JsonSchemasTest extends AnyFreeSpec {
         assert(r.name == "MutualRecursiveA")
         assert(
           r.value == DocumentedRecord(
-            List(Field("b", DocumentedJsonSchemas.mutualRecursiveB.docs, true, None)),
+            List(Field("b", DocumentedJsonSchemas.mutualRecursiveB.docs, true, None, None)),
             None,
             None,
             None,
@@ -215,6 +225,7 @@ class JsonSchemasTest extends AnyFreeSpec {
               "next",
               r,
               isOptional = true,
+              defaultValue = None,
               documentation = None
             )
             val expectedA = DocumentedRecord(
@@ -222,6 +233,7 @@ class JsonSchemasTest extends AnyFreeSpec {
                 "a",
                 DocumentedJsonSchemas.defaultStringJsonSchema.docs,
                 isOptional = false,
+                defaultValue = None,
                 documentation = None
               )
                 :: expectedNext
@@ -232,6 +244,7 @@ class JsonSchemasTest extends AnyFreeSpec {
                 "b",
                 DocumentedJsonSchemas.intJsonSchema.docs,
                 isOptional = false,
+                defaultValue = None,
                 documentation = None
               )
                 :: expectedNext
@@ -276,4 +289,25 @@ class JsonSchemasTest extends AnyFreeSpec {
     assert(DocumentedJsonSchemas.constraintNumericSchema.docs == expected)
   }
 
+  "optional field with default" in {
+    val expectedSchema =
+      DocumentedRecord(
+        Field(
+          "name",
+          DocumentedJsonSchemas.defaultStringJsonSchema.docs,
+          isOptional = false,
+          defaultValue = None,
+          documentation = Some("Name of the user")
+        ) ::
+          Field(
+            "age",
+            DocumentedJsonSchemas.intJsonSchema.docs,
+            isOptional = true,
+            defaultValue = Some(ujson.Num(42)),
+            documentation = None
+          ) ::
+          Nil
+      )
+    assert(DocumentedJsonSchemas.User.schemaWithDefault.docs == expectedSchema)
+  }
 }


### PR DESCRIPTION
`optFieldWithDefault` is no longer final and the OpenAPI interpreter
overrides it so as to track the default value in the documentation.

Fixes #880