### PR TITLE
fix http4s output encoding to UTF-8

### DIFF
--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -93,6 +93,6 @@ private object JsonEntities {
       endpoints: EndpointsWithCustomErrors
   )(encoder: Encoder[A, String]): endpoints.ResponseEntity[A] =
     EntityEncoder[endpoints.Effect, Chunk[Byte]]
-      .contramap[A](value => Chunk.array(encoder.encode(value).getBytes("UTF-8")))
+      .contramap[A](value => Chunk.array(encoder.encode(value).getBytes(http4s.Charset.`UTF-8`.nioCharset)))
       .withContentType(`Content-Type`(MediaType.application.json))
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -93,6 +93,6 @@ private object JsonEntities {
       endpoints: EndpointsWithCustomErrors
   )(encoder: Encoder[A, String]): endpoints.ResponseEntity[A] =
     EntityEncoder[endpoints.Effect, Chunk[Byte]]
-      .contramap[A](value => Chunk.array(encoder.encode(value).getBytes()))
+      .contramap[A](value => Chunk.array(encoder.encode(value).getBytes("UTF-8")))
       .withContentType(`Content-Type`(MediaType.application.json))
 }

--- a/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
+++ b/http4s/server/src/main/scala/endpoints4s/http4s/server/JsonEntities.scala
@@ -93,6 +93,8 @@ private object JsonEntities {
       endpoints: EndpointsWithCustomErrors
   )(encoder: Encoder[A, String]): endpoints.ResponseEntity[A] =
     EntityEncoder[endpoints.Effect, Chunk[Byte]]
-      .contramap[A](value => Chunk.array(encoder.encode(value).getBytes(http4s.Charset.`UTF-8`.nioCharset)))
+      .contramap[A](value =>
+        Chunk.array(encoder.encode(value).getBytes(http4s.Charset.`UTF-8`.nioCharset))
+      )
       .withContentType(`Content-Type`(MediaType.application.json))
 }


### PR DESCRIPTION
Currently, in http4s server JsonEntities outputs String with default charset. This is a problem in my case, which is Windows OS in Japan with default charset of windows-31j (Shift-JIS). If I set environ variable JAVA_TOOL_OPTIONS to be '-Dfile.encoding=UTF8', output is encoded with UTF-8 as expected. However, if output is encoded properly without setting the environment variable, it would be better. The cause of this behavior seems to be encodeJsonResponse method of JsonEntities uses getBytes(), which encodes with default charset. By modifying it to getBytes("UTF-8"), it becomes to encode output with UTF-8 irrespective of default charset. I think the modified behavior is favorable because almost anyone expected Json strings are encoded with UTF-8. So, would you please consider incorporating thie modification to the library code? 