### PR TITLE
Add ability to create int based enum json schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / sonatypeProjectHosting := Some(
 // We want to keep binary compatibility as long as we can for the algebra,
 // but it is OK to publish breaking releases of interpreters. So,
 // interpreter modules may override this setting.
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // Ignore dependencies to modules with version like `1.2.3+n`
 ThisBuild / versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+n".r)
 // Default version, used by the algebra modules, and by the interpreters,

--- a/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
+++ b/json-schema/json-schema/src/main/scala/endpoints4s/algebra/JsonSchemas.scala
@@ -132,7 +132,10 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
 
   /** A more specific type of JSON schema for enumerations, i.e. types that have a specific set of valid values
     *
-    * Values of type `Enum[A]` can be constructed by the operations [[enumeration]] and [[stringEnumeration]].
+    * Values of type `Enum[A]` can be constructed by the operations:
+    *  - [[enumeration]]
+    *  - [[stringEnumeration]]
+    *  - [[intEnumeration]]
     *
     * @note This type has implicit methods provided by the [[EnumOps]] class.
     * @group types
@@ -157,7 +160,22 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
     */
   final def stringEnumeration[A](
       values: Seq[A]
-  )(encode: A => String)(implicit tpe: JsonSchema[String]): Enum[A] = {
+  )(encode: A => String)(implicit tpe: JsonSchema[String]): Enum[A] =
+    valueEnumeration(values)(encode)(tpe)
+
+  /** Convenient constructor for enumerations represented by int values.
+    * @group operations
+    */
+  final def intEnumeration[A](
+      values: Seq[A]
+  )(encode: A => Int)(implicit tpe: JsonSchema[Int]): Enum[A] =
+    valueEnumeration(values)(encode)(tpe)
+
+  /** Helper function to construct enumerations represented by values of some base type.
+    */
+  private def valueEnumeration[V, A](
+      values: Seq[A]
+  )(encode: A => V)(valueSchema: JsonSchema[V]): Enum[A] = {
     val encoded = values.map(a => (a, encode(a))).toMap
     val decoded = encoded.map(_.swap)
     assert(
@@ -165,9 +183,9 @@ trait JsonSchemas extends TuplesSchemas with PartialInvariantFunctorSyntax {
       "Enumeration values must have different string representation"
     )
     enumeration(values)(
-      tpe.xmapPartial { str =>
-        Validated.fromOption(decoded.get(str))(
-          s"Invalid value: ${str} ; valid values are: ${values.map(encode).mkString(", ")}"
+      valueSchema.xmapPartial { value =>
+        Validated.fromOption(decoded.get(value))(
+          s"Invalid value: $value ; valid values are: ${values.map(encode).mkString(", ")}"
         )
       }(encode)
     )

--- a/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasFixtures.scala
+++ b/json-schema/json-schema/src/test/scala/endpoints4s/algebra/JsonSchemasFixtures.scala
@@ -90,6 +90,16 @@ trait JsonSchemasFixtures extends JsonSchemas {
       stringEnumeration[Color](Seq(Red, Blue))(_.toString).named("Color")
   }
 
+  object IntValueEnum {
+    sealed abstract class IntValueEnum(val value: Int)
+    case object One extends IntValueEnum(1)
+    case object Two extends IntValueEnum(2)
+    case object Three extends IntValueEnum(3)
+
+    val intValueEnumSchema: Enum[IntValueEnum] =
+      intEnumeration[IntValueEnum](Seq(One, Two, Three))(_.value).named("IntValue")
+  }
+
   object NonStringEnum {
     case class Foo(quux: String)
 

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/JsonSchemasTest.scala
@@ -95,6 +95,16 @@ class JsonSchemasTest extends AnyFreeSpec {
     assert(DocumentedJsonSchemas.Enum.colorSchema.docs == expectedSchema)
   }
 
+  "int value enum" in {
+    val expectedSchema =
+      DocumentedEnum(
+        DocumentedJsonSchemas.intJsonSchema.docs,
+        ujson.Num(1) :: ujson.Num(2) :: ujson.Num(3) :: Nil,
+        Some("IntValue")
+      )
+    assert(DocumentedJsonSchemas.IntValueEnum.intValueEnumSchema.docs == expectedSchema)
+  }
+
   "non-string enum" in {
     val expectedSchema =
       DocumentedEnum(

--- a/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasTest.scala
@@ -334,6 +334,24 @@ class JsonSchemasTest extends AnyFreeSpec {
     )
   }
 
+  "int value enum" in {
+    checkRoundTrip(
+      IntValueEnum.intValueEnumSchema,
+      ujson.Num(2),
+      IntValueEnum.Two
+    )
+    checkDecodingFailure(
+      IntValueEnum.intValueEnumSchema,
+      ujson.Str("invalid"),
+      "Invalid integer value: \"invalid\"" :: Nil
+    )
+    checkDecodingFailure(
+      IntValueEnum.intValueEnumSchema,
+      ujson.Num(4),
+      "Invalid value: 4 ; valid values are: 1, 2, 3" :: Nil
+    )
+  }
+
   "non-string enum" in {
     assert(
       NonStringEnum.enumSchema.codec.encode(NonStringEnum.Foo("bar")) == ujson


### PR DESCRIPTION
It may be useful to allow creating value based enums, not only based by strings (at least the ones backed by integers).
There is no open issue for this, but I have faced such a need during my recent work experience.