### PR TITLE
Redesign Request implementation in http4s and akka-http interpreters

### DIFF
--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -44,6 +44,7 @@ val `akka-http-server` =
       `scala 2.12 to dotty`,
       name := "akka-http-server",
       version := "6.1.0+n",
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-http" % akkaHttpVersion).cross(CrossVersion.for3Use2_13),
         ("com.typesafe.akka" %% "akka-stream" % akkaActorVersion % Provided).cross(CrossVersion.for3Use2_13),

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/BasicAuthentication.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/BasicAuthentication.scala
@@ -6,11 +6,11 @@ import akka.http.scaladsl.model.headers.{
   HttpChallenges,
   `WWW-Authenticate`
 }
-import akka.http.scaladsl.model.{HttpHeader, HttpResponse, StatusCodes => AkkaStatusCodes}
+import akka.http.scaladsl.model.{HttpHeader, HttpResponse, Uri, StatusCodes => AkkaStatusCodes}
 import akka.http.scaladsl.server.{Directive1, Directives}
 import endpoints4s.algebra.BasicAuthentication.Credentials
 import endpoints4s.algebra.Documentation
-import endpoints4s.{Tupler, Valid, Validated, algebra}
+import endpoints4s.{Invalid, Tupler, Valid, Validated, algebra}
 
 /** @group interpreters
   */
@@ -27,33 +27,8 @@ trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWith
       tuplerHCred: Tupler.Aux[H, Credentials, HCred],
       tuplerUEHCred: Tupler.Aux[UE, HCred, Out]
   ): Request[Out] = {
-    val (m, u, e, h) = (method, url, entity, headers)
     new Request[Out] {
-      type UrlData = U
-      type HeadersData = (H, Option[Credentials])
-      type EntityData = E
-
-      def url: Url[UrlData] = u
-      def method: Method = m
-      def entity: RequestEntity[EntityData] = e
-      def headers: RequestHeaders[HeadersData] = h ++ authHeader
-
-      private[server] def aggregateAndValidate(
-          urlData: UrlData,
-          entityData: EntityData,
-          headersData: HeadersData
-      ): Validated[Out] =
-        headersData match {
-          case (_, None) =>
-            // Note: in practice that should not happen because the method `aggregateAndValidate` is
-            // only called from the final method `matches`, if `matchAndParseHeaders` succeeded.
-            // However, here we override `matchAndParseHeaders` to fail in case the credentials are missing.
-            sys.error(
-              "This request transformation is currently unsupported. You can't transform further an authenticated request."
-            )
-          case (h, Some(credentials)) =>
-            Valid(tuplerUEHCred(tuplerUE(urlData, entityData), tuplerHCred(h, credentials)))
-        }
+      type UrlAndHeaders = (U, H, Credentials)
 
       lazy val authHeader: RequestHeaders[Option[Credentials]] =
         httpHeaders =>
@@ -65,10 +40,9 @@ trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWith
             }
           )
 
-      private[server] def matchAndParseHeadersDirective
-          : Directive1[Validated[(UrlData, HeadersData)]] =
-        matchAndProvideParsedUrlAndHeadersData(method, url, headers).flatMap {
-          case Valid((_, (_, None /* credentials */ ))) =>
+      lazy val matchAndParseHeadersDirective: Directive1[Validated[UrlAndHeaders]] =
+        Directives.extractRequest.map(authHeader.decode).flatMap {
+          case Valid(None) =>
             Directives.complete(
               HttpResponse(
                 AkkaStatusCodes.Unauthorized,
@@ -77,14 +51,24 @@ trait BasicAuthentication extends algebra.BasicAuthentication with EndpointsWith
                 )
               )
             )
-          case validatedUrlAndHeaders => Directives.provide(validatedUrlAndHeaders)
+          case Valid(Some(credentials)) =>
+            matchAndProvideParsedUrlAndHeadersData(method, url, headers)
+              .map(_.map { case (u, h) => (u, h, credentials) })
+          case invalid: Invalid => Directives.provide(invalid)
         }
 
-      def urlData(out: Out): UrlData = {
+      def parseEntityDirective(urlAndHeaders: UrlAndHeaders): Directive1[Out] =
+        entity.map { e =>
+          val (u, h, c) = urlAndHeaders
+          tuplerUEHCred(tuplerUE(u, e), tuplerHCred(h, c))
+        }
+
+      def uri(out: Out): Uri = {
         val (ue, _) = tuplerUEHCred.unapply(out)
         val (u, _) = tuplerUE.unapply(ue)
-        u
+        url.uri(u)
       }
+
     }
   }
 

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Endpoints.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Endpoints.scala
@@ -37,7 +37,24 @@ trait EndpointsWithCustomErrors
     /** Information extracted from the URL and the headers */
     type UrlAndHeaders
 
-    /** A directive that extracts an `A` from an incoming request */
+    /** Directive matching and parsing the content of an incoming request.
+      *
+      * First, it checks whether the incoming request matches the request URL
+      * and method. If this is the case, it parses the request headers and
+      * proceeds to the second step.
+      *
+      * If there were no validation errors when parsing the request URL and
+      * headers, it parses the request entity.
+      *
+      * The directive can produce:
+      *
+      *   - a ''rejection'' to signal that the incoming request does not
+      *     match this request description,
+      *   - a ''completion'' containing an error response (e.g., in case
+      *     of validation errors),
+      *   - a value of type `A` parsed from the request content (URL, headers,
+      *     and entity).
+      */
     final lazy val directive: Directive1[A] =
       matchAndParseHeadersDirective.flatMap {
         case invalid: Invalid     => handleClientErrors(invalid)

--- a/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Urls.scala
+++ b/akka-http/server/src/main/scala/endpoints4s/akkahttp/server/Urls.scala
@@ -60,19 +60,6 @@ trait Urls extends algebra.Urls with StatusCodes {
         query: Map[String, List[String]]
     ): Option[Validated[A]]
 
-    private[server] final def addQueryString[B](queryString: QueryString[B]): Url[(A, B)] =
-      new Url[(A, B)] {
-        def validateUrl(
-            segments: List[String],
-            query: Map[String, List[String]]
-        ): Option[Validated[(A, B)]] =
-          outer.validateUrl(segments, query).map(_.zip(queryString.validate(query)))
-        def uri(ab: (A, B)): Uri = {
-          val outerUri = outer.uri(ab._1)
-          outerUri.withQuery(Uri.Query(outerUri.query() ++ queryString.encode(ab._2): _*))
-        }
-      }
-
     final def directive: Directive1[Validated[A]] = {
       (Directives.extractUri & Directives.path(
         Directives.Segments ~ Directives.Slash.?

--- a/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/RequestUriTest.scala
+++ b/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/RequestUriTest.scala
@@ -14,6 +14,7 @@ class RequestUriTest extends AnyWordSpec {
       ]("s", 1) & qs[List[String]]("t"))
     val p4 = path / "a" /? qs[Option[Int]]("x")
     val e = endpoint(get(p4), ok(textResponse))
+    val f = endpoint(get(p4).addQueryString(qs[Int]("y")), ok(emptyResponse))
   }
 
   object Fixtures extends Fixtures with Endpoints
@@ -30,6 +31,10 @@ class RequestUriTest extends AnyWordSpec {
       )
       assert(p4.uri(None).toString == "/a")
       assert(e.uri(Some(42)).toString == "/a?x=42")
+    }
+    "properly encode URIs of transformed endpoint descriptions" in {
+      import Fixtures.f
+      assert(f.uri((Some(42), 0)).toString == "/a?x=42&y=0")
     }
   }
 

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -20,6 +20,7 @@ val `http4s-server` =
       `scala 2.12 to dotty`,
       name := "http4s-server",
       version := "9.0.0+n",
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.http4s" %% "http4s-core" % http4sVersion,
         "org.http4s" %% "http4s-dsl" % http4sVersion,

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/ChunkedEntitiesServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/ChunkedEntitiesServerInterpreterTest.scala
@@ -4,7 +4,6 @@ import java.net.ServerSocket
 
 import endpoints4s.{Invalid, Valid}
 import endpoints4s.algebra.server.{
-  BasicAuthenticationTestSuite,
   ChunkedJsonEntitiesTestSuite,
   DecodedUrl,
   EndpointsTestSuite
@@ -26,7 +25,6 @@ import cats.effect.IO
 
 class ChunkedEntitiesServerInterpreterTest
     extends EndpointsTestSuite[ChunkedEntitiesEndpointsTestApi]
-    with BasicAuthenticationTestSuite[ChunkedEntitiesEndpointsTestApi]
     with ChunkedJsonEntitiesTestSuite[ChunkedEntitiesEndpointsTestApi] {
 
   val serverApi = new ChunkedEntitiesEndpointsTestApi()


### PR DESCRIPTION
The previous design was leading to brittle situations (see the changes on the BasicAuthentication interpreters). I believe the new design is simpler (it also requires less boilerplate).

I also changed the behavior of the BasicAuthentication interpreter to reject early incoming requests that don’t provide authentication credentials.

---

I only changed the interpreters’ implementation, not the algebra, which remains unchanged (with `mapRequest`, `mapResponse`, etc.).

For instance, the previous implementation of `Request` in the akka-http-server interpreter was the following:

~~~ scala
  trait Request[A] {
    type HeadersData
    type EntityData
    type UrlData
    def url: Url[UrlData]
    def headers: RequestHeaders[HeadersData]
    def method: Method
    def urlData(a: A): UrlData
    def entity: RequestEntity[EntityData]

    /** A directive that extracts an `A` from an incoming request */
    final lazy val directive: Directive1[A] =
      matchAndParseHeadersDirective.flatMap {
        case invalid: Invalid => handleClientErrors(invalid)
        case Valid((urlData, headersData)) =>
          entity.flatMap { entityData =>
            val validated = aggregateAndValidate(urlData, entityData, headersData)
            validated match {
              case Valid(value)     => Directives.provide(value)
              case invalid: Invalid => handleClientErrors(invalid)
            }
          }
      }

    /** Checks whether the incoming request matches this request description, and
      * if this is the case, parses its URL parameters and headers.
      */
    private[server] def matchAndParseHeadersDirective: Directive1[Validated[(UrlData, HeadersData)]]

    /** The URI of a request carrying the given `a` parameter */
    final def uri(a: A): Uri = url.uri(urlData(a))

    private[server] def aggregateAndValidate(
        urlData: UrlData,
        entityData: EntityData,
        headersData: HeadersData
    ): Validated[A]
  }
~~~

It contains 3 abstract type members, and several abstract methods. Some of them were even `private` (e.g., `aggregateAndValidate`) making it impossible to implement outside of endpoints4s! (I initially wanted to make them private to have some margin for changing the implementation details, but the result is impractical to use)

The new design is the following:

~~~ scala
  trait Request[A] {

    type UrlAndHeaders

    /** A directive that extracts an `A` from an incoming request */
    final lazy val directive: Directive1[A] =
      matchAndParseHeadersDirective.flatMap {
        case invalid: Invalid     => handleClientErrors(invalid)
        case Valid(urlAndHeaders) => parseEntityDirective(urlAndHeaders)
      }

    /** Checks whether the incoming request matches this request description, and
      * if this is the case, parses its URL parameters and headers.
      */
    def matchAndParseHeadersDirective: Directive1[Validated[UrlAndHeaders]]

    /** Parses the request entity.
      */
    def parseEntityDirective(urlAndHeaders: UrlAndHeaders): Directive1[A]

    /** The URI of a request carrying the given `a` parameter */
    def uri(a: A): Uri
  }
~~~

It contains only 1 abstract type member, and has fewer abstract methods. It has a public final member `directive` that provides the logic for processing a request. It works in two stages.

First, we check whether the incoming request matches the endpoint description (by its method and URL), and if this is the case we parse all the information from the URL and headers. This first stage is achieved by the abstract method `matchAndParseHeadersDirective`, which can either immediately return an error response, or provide the information parsed from the URL and headers.

Second, we parse the request entity and we combine it with the information previously parsed from the URL and headers to produce the resulting value of type `A` (for a `Request[A]`). That part is achieved by the abstract method `parseEntityDirective`.

The implementation of `Request[A]` in the http4s interpreter follows a similar design.

---

The concrete implementation of `Request[A]` usually does not matter much to the end users, except when they want to do advanced stuff where they need to implement their own instance of `Request[A]`. This is, for instance, the case with authentication support. In the future, the complete implementation of middlewares should allow the users to implement things like custom authentication even without having to implement their own instances of `Request[A]`, but there will probably be some cases where this will be still necessary.

Let’s look at the changes of the `example-authenticated` module (which uses http4s) to see the improvement. Before the PR, we implemented our instance of `Request` as follows:

~~~ scala
  def authenticatedRequest[U, E, UE, UET](
      method: Method,
      url: Url[U],
      entity: RequestEntity[E]
  )(implicit
      tuplerUE: Tupler.Aux[U, E, UE],
      tuplerUET: Tupler.Aux[UE, AuthenticationToken, UET]
  ): Request[UET] = {
    // alias parameters to not clash with `Request` members
    val urlArg = url
    val methodArg = method
    val entityArg = entity

    new Request[UET] {
      type UrlData = U
      type HeadersData = Option[AuthenticationToken]
      type EntityData = E

      def url: Url[U] = urlArg
      def headers: RequestHeaders[Option[UserInfo]] = authenticationTokenRequestHeaders
      def method: Method = methodArg
      def entity: RequestEntity[E] = entityArg

      def aggregateAndValidate(
          urlData: U,
          headersData: Option[UserInfo],
          entityData: E
      ): Validated[UET] =
        headersData match {
          case None        => sys.error("Unsupported")
          case Some(token) => Valid(tuplerUET(tuplerUE(urlData, entityData), token))
        }

      def matchAndParseHeaders(
          http4sRequest: org.http4s.Request[F]
      ): Option[Either[org.http4s.Response[F], Validated[(UrlData, HeadersData)]]] =
        matchAndParseHeadersAsRight(method, url, headers, http4sRequest).map(_.flatMap {
          case Valid((_, None /* credentials */ )) => Left(org.http4s.Response(Unauthorized))
          case validatedUrlAndHeaders              => Right(validatedUrlAndHeaders)
        })

    }
  }
~~~

In this PR, this is now as follows:

~~~ scala
  def authenticatedRequest[U, E, UE, UET](
      method: Method,
      url: Url[U],
      entity: RequestEntity[E]
  )(implicit
      tuplerUE: Tupler.Aux[U, E, UE],
      tuplerUET: Tupler.Aux[UE, AuthenticationToken, UET]
  ): Request[UET] =
    new Request[UET] {

      // Data extracted from the incoming request
      type UrlAndHeaders = (U, AuthenticationToken)

      def matchAndParseHeaders(
          http4sRequest: org.http4s.Request[F]
      ): Option[Either[org.http4s.Response[F], Validated[UrlAndHeaders]]] =
        // First, check whether the incoming request matches this request description
        matchAndParseHeadersAsRight(method, url, emptyRequestHeaders, http4sRequest)
          // If this is the case, check whether there is a token in the request headers or not
          .map { errorResponseOrValidatedUrlAndHeaders =>
            authenticationTokenRequestHeaders(http4sRequest.headers) match {
              // There is a token, just add it to the
              case Valid(Some(token)) =>
                errorResponseOrValidatedUrlAndHeaders
                  .map(_.map { case (u, _) => (u, token) })
              case _ => Left(org.http4s.Response(Unauthorized))
            }
          }

      def parseEntity(
          urlAndHeaders: UrlAndHeaders,
          http4sRequest: org.http4s.Request[F]
      ): Effect[Either[org.http4s.Response[F], UET]] =
        entity(http4sRequest).map(_.map { entityData =>
          val (urlData, token) = urlAndHeaders
          tuplerUET(tuplerUE(urlData, entityData), token)
        })

    }
~~~

Not only the new implementation is more concise, but it also removes the need to write `case None => sys.error("Unsupported")` that we previously had to handle even though that case was impossible to reach in practice.

With the design proposed in this PR, end-users have two “points of control” when they implement a `Request[A]`, which correspond to the two steps I explained above: checking whether the incoming request matches this request description (and parsing the URL and headers at the same time), or parsing the request entity (and aggregating it with the parsed URL and headers data to produce an `A`). Here, we act on the first step: we checked whether the incoming request matches this request description by calling `matchAndParseHeadersAsRight` and, in case the incoming request does match, we look into its headers to see if there is an authentication token. If it is missing, we can immediately return an error response. Otherwise, we add it to the content of the parsed URL. The implementation of the second stage parses the request entity and then uses the tuplers to build an `A` from the URL data, entity data, and token.

---

Possible variations around the design proposed in the PR:

- [ ] make the abstract methods in `Request[A]` `protected` instead of `public`
- [ ] change signature of `parseEntity` to return a `Validated[A]` instead of an `A`, to make it more straightforward to implement for end-users. Currently, users have to be careful to call `handleClientErrors` to handle validation errors. That could be done for them automatically if validation errors were returned as a `Validated` value.