### PR TITLE
Cross-test with Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         java-version: adopt@1.11
     - run: npm install jsdom@12.2.0
-    - run: sbt stub-server/bgRun ++2.12.13 test
+    - run: sbt stub-server/bgRun "++ 2.12 test"
 
   test213:
     name: Test (Scala 2.13)
@@ -33,7 +33,7 @@ jobs:
         java-version: adopt@1.11
     - run: npm install jsdom@12.2.0
     - run: sudo apt-get install graphviz
-    - run: sbt stub-server/bgRun ++2.13.8 coverage test coverageReport coverageAggregate manual/makeSite
+    - run: sbt stub-server/bgRun "++ 2.13 ;coverage ;test ;coverageReport ;coverageAggregate ;manual/makeSite"
     - run: bash <(curl -s https://codecov.io/bash)
 
   test3:
@@ -46,7 +46,7 @@ jobs:
       with:
         java-version: adopt@1.11
     - run: npm install jsdom@12.2.0
-    - run: sbt "++ 3.1.2 compile" "stub-server/bgRun; ++ 3.1.2 ;json-schemaJVM/test;json-schemaJS/test;json-schemaNative/test;json-schema-playjsonJVM/test;json-schema-playjsonJS/test;json-schema-genericJVM/test;json-schema-genericJS/test;algebraJVM/test;algebraJS/test;algebraNative/test;fetch-client/test;fetch-client-circe/test"
+    - run: sbt stub-server/bgRun "++ 3 test"
 
   versionPolicy:
     name: Check versioning policy and code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ After generating intellij project you may need to navigate to Settings -> Langua
    ~~~
 5. Upload the bundles to sonatype, release them, and publish the documentation website
    ~~~ sh
-   sbt "++ 2.12.13 publishSigned" "++ 2.13.8 publishSigned" sonatypeReleaseAll "++ 2.13.8 manual/makeSite" manual/ghpagesPushSite
+   sbt "+publishSigned" sonatypeReleaseAll "++ 2.13 manual/makeSite" manual/ghpagesPushSite
    ~~~
 6. Create a tag `vx.y.z`
    ~~~ sh

--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -55,7 +55,6 @@ val `akka-http-server` =
       excludeDependencies ++= {
         if (scalaBinaryVersion.value.startsWith("3")) {
           List(
-            ExclusionRule("org.scala-lang.modules", "scala-xml_3"),
             ExclusionRule("org.scala-lang.modules", "scala-collection-compat_2.13")
           )
         } else Nil

--- a/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/ServerInterpreterTest.scala
+++ b/akka-http/server/src/test/scala/endpoints4s/akkahttp/server/ServerInterpreterTest.scala
@@ -2,7 +2,13 @@ package endpoints4s.akkahttp.server
 
 import java.net.ServerSocket
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, Uri, StatusCodes => AkkaStatusCodes}
+import akka.http.scaladsl.model.{
+  HttpEntity,
+  HttpRequest,
+  HttpResponse,
+  Uri,
+  StatusCodes => AkkaStatusCodes
+}
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Source
@@ -72,10 +78,12 @@ class ServerInterpreterTest
     import java.io._
 
     val directive =
-      url.directive.map {
-        case Valid(a)        => DecodedUrl.Matched(a)
-        case Invalid(errors) => DecodedUrl.Malformed(errors)
-      }.or[Tuple1[DecodedUrl[A]]](Directives.provide(DecodedUrl.NotMatched))
+      url.directive
+        .map {
+          case Valid(a)        => DecodedUrl.Matched(a)
+          case Invalid(errors) => DecodedUrl.Malformed(errors)
+        }
+        .or[Tuple1[DecodedUrl[A]]](Directives.provide(DecodedUrl.NotMatched))
 
     val route = directive { decodedA => req =>
       val baos = new ByteArrayOutputStream

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/ChunkedEntitiesServerInterpreterTest.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/ChunkedEntitiesServerInterpreterTest.scala
@@ -29,7 +29,7 @@ class ChunkedEntitiesServerInterpreterTest
 
   val serverApi = new ChunkedEntitiesEndpointsTestApi()
 
-  implicit val system = ActorSystem()
+  implicit val system: ActorSystem = ActorSystem()
   implicit val materializer: Materializer = Materializer.createMaterializer(system)
 
   override def serveStreamedEndpoint[Req, Resp, Mat](

--- a/http4s/server/src/test/scala/endpoints4s/http4s/server/Converter.scala
+++ b/http4s/server/src/test/scala/endpoints4s/http4s/server/Converter.scala
@@ -105,7 +105,7 @@ trait Converter {
         })
         callback.map(_ => stream)
       }
-    } yield { in: Stream[IO, A] =>
+    } yield { (in: Stream[IO, A]) =>
       {
         // Async wait on the promise to be completed
         val materializedResultStream = Stream.eval(promise.get)
@@ -265,10 +265,10 @@ trait Converter {
       .interruptWhen(watchCompletion.attempt)
       .evalMap(publish)
       .unNoneTerminate
-      .onFinalizeCase { 
-	case Canceled => complete
-	case Errored(e) => fail(e)
-	case Succeeded => complete
+      .onFinalizeCase {
+        case Canceled => complete
+        case Errored(e) => fail(e)
+        case Succeeded => complete
       }
   }
 

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -65,7 +65,7 @@ object EndpointsSettings {
     crossScalaVersions := Seq("2.13.8", "2.12.13")
   )
   val `scala 2.12 to dotty` = Seq(
-    scalaVersion := "2.13.8",
+    scalaVersion := "3.1.2",
     crossScalaVersions := Seq("2.13.8", "3.1.2", "2.12.13")
   )
 
@@ -101,7 +101,7 @@ object EndpointsSettings {
   val playjsonVersion = "2.9.2"
   val playVersion = "2.8.13"
   val sttpVersion = "3.3.15"
-  val akkaActorVersion = "2.6.15"
+  val akkaActorVersion = "2.6.17"
   val akkaHttpVersion = "10.2.6"
   val http4sVersion = "0.23.6"
   val http4sDomVersion = "0.2.0"

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -65,7 +65,7 @@ object EndpointsSettings {
     crossScalaVersions := Seq("2.13.8", "2.12.13")
   )
   val `scala 2.12 to dotty` = Seq(
-    scalaVersion := "3.1.2",
+    scalaVersion := "2.13.8",
     crossScalaVersions := Seq("2.13.8", "3.1.2", "2.12.13")
   )
 


### PR DESCRIPTION
Remaining issues

- [x] Fix compilation of http4s-server tests. There seems to be an issue in the usage of the Akka-http graph DSL in Scala 3. We use it to convert between Akka-streams and http4s streams.
- [x] Compilation of openapi module loops indefinitely

Relates to #566