### PR TITLE
Set up release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
-name: CI
+name: Continuous Integration
 on:
   push:
     branches:
     - master
-    tags:
-    - "v*"
   pull_request:
 
 jobs:
@@ -12,12 +10,12 @@ jobs:
     name: Test (Scala 2.12)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: coursier/cache-action@v5
-    - uses: actions/setup-node@v2
-    - uses: olafurpg/setup-scala@v10
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
-        java-version: adopt@1.11
+        distribution: temurin
+        java-version: 11
+        cache: sbt
     - run: npm install jsdom@12.2.0
     - run: sbt stub-server/bgRun "++ 2.12 test"
 
@@ -25,12 +23,12 @@ jobs:
     name: Test (Scala 2.13)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: coursier/cache-action@v5
-    - uses: actions/setup-node@v2
-    - uses: olafurpg/setup-scala@v10
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
-        java-version: adopt@1.11
+        distribution: temurin
+        java-version: 11
+        cache: sbt
     - run: npm install jsdom@12.2.0
     - run: sudo apt-get install graphviz
     - run: sbt stub-server/bgRun "++ 2.13 ;coverage ;test ;coverageReport ;coverageAggregate ;manual/makeSite"
@@ -40,11 +38,12 @@ jobs:
     name: Test (Scala 3)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: coursier/cache-action@v5
-    - uses: olafurpg/setup-scala@v10
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
-        java-version: adopt@1.11
+        distribution: temurin
+        java-version: 11
+        cache: sbt
     - run: npm install jsdom@12.2.0
     - run: sbt stub-server/bgRun "++ 3 test"
 
@@ -52,11 +51,10 @@ jobs:
     name: Check versioning policy and code style
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
-        fetch-depth: 0
-    - uses: coursier/cache-action@v5
-    - uses: olafurpg/setup-scala@v10
-      with:
-        java-version: adopt@1.11
+        distribution: temurin
+        java-version: 11
+        cache: sbt
     - run: sbt versionPolicyCheck scalafmtCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      versionQualifier:
+        description: 'Version qualifier (e.g. "-RC1")'
+        required: false
+        type: string
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    env:
+      RELEASE: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+      - run: npm install jsdom@12.2.0
+      - name: Set version qualifier
+        run: |
+          echo "VERSION_QUALIFIER=${{ inputs.versionQualifier }}" >> $GITHUB_ENV
+        if: ${{ inputs.versionQualifier != '' }}
+      - run: sbt release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,23 +19,27 @@ sbt-assets/                 Sbt plugin to help handling assets
 
 ## Cheat sheet
 
+Start the `sbt` shell from the project root directory. Then run the following command from
+the sbt prompt.
+
 ### Compile the project with the default Scala version
 
-~~~ sh
-$ sbt compile
+~~~
+> compile
 ~~~
 
 ### Run the tests
 
-~~~ sh
-$ sbt test
+~~~
+> sbt test
 ~~~
 
 Or, for a specific Scala version:
 
-~~~ sh
-$ sbt "++ 2.12.13 test"
-$ sbt "++ 2.13.8 test"
+~~~
+> ++ 2.12 test
+> ++ 2.13 test
+> ++ 3 test
 ~~~
 
 ### Introduction of source or binary incompatibilities
@@ -65,8 +69,8 @@ and to manage the release versions accordingly.
 To check that your changes don’t break the versioning policy, run the task
 `versionPolicyCheck`:
 
-~~~ sh
-$ sbt versionPolicyCheck
+~~~
+> versionPolicyCheck
 ~~~
 
 If this task fails, either find a way to implement your contribution in a
@@ -77,88 +81,61 @@ by changing its setting `versionPolicyIntention`.
 
 We use Scalafmt. You can use the `scalafmt` sbt task like the following:
 
-~~~ sh
+~~~
 > scalafmt
 ~~~
 
 ### Preview the documentation
 
-~~~ sh
-$ sbt manual/previewSite
+~~~
+> manual/previewSite
 ~~~
 
 And then go to http://localhost:4000.
 
 ### Publish the documentation
 
-~~~ sh
-$ sbt manual/ghpagesPushSite
+~~~
+> manual/ghpagesPushSite
 ~~~
 
 ### Run the examples 
 
-~~~ sh
-++ 2.13.8 example-basic-play-server/run
 ~~~
-
-## Working with mill
-
-Endpoints comes with experimental mill build which is meant for evaluating mill as a replacecement for sbt
-
-~~~sh
-mill genidea #generate idea project config
-mill all __.compile #compile everything
-mill all __.test #test everything
+> ++ 2.13 example-basic-play-server/run
 ~~~
-After generating intellij project you may need to navigate to Settings -> Languages & Frameworks -> Worksheet and set inteprpretation mode to "Always Ammonite"
 
 ## Release process
 
-1. Make sure the release notes for the next release are ready (https://github.com/endpoints4s/endpoints4s/releases)
-   Every PR should be listed (except @scala-steward’s PRs), and there should be a table at the
-   beginning of the release notes, summarizing the modules’ versions and their dependencies’
+We use `sbt-release`, and we cut a release by manually triggering the `release` GitHub workflow.
+
+1. Make sure the draft release notes for the next release (https://github.com/endpoints4s/endpoints4s/releases)
+   list all the PRs that have been merged (except @scala-steward’s PRs).
+2. Run the [release](https://github.com/endpoints4s/endpoints4s/actions/workflows/release.yml) workflow from the GitHub UI.
+3. The workflow will compute the next release version for every artifact, run the compatibility checks, publish
+   the artifacts, push a Git tag (matching the version of the algebra), and update the documentation website.
+4. In the GitHub [releases](https://github.com/endpoints4s/endpoints4s/releases) page, associate the draft
+   release with the tag that has just been pushed, and update it to include a table at the
+   beginning of the release notes summarizing the modules’ versions and their dependencies’
    versions.
-2. Bump the version of every module (e.g., change `1.0.0+n` into `1.0.1`, `1.1.0`, or `2.0.0`,
-   according to the compatibility guarantees of the module). If a module does not define its
-   version (this is the case for all the modules that only provide algebras), it uses the one
-   defined in the root file `build.sbt`. All the interpreters have their own version numbers
-   and compatibility guarantees, so they all define both settings `versionPolicyIntention` and
-   `version`.
-3. Commit the new versions
-   ~~~ sh
-   git commit -a -m "Set release versions"
-   ~~~
-4. Run `versionPolicyCheck` and `versionCheck`
-   ~~~ sh
-   sbt versionPolicyCheck versionCheck
-   ~~~
-5. Upload the bundles to sonatype, release them, and publish the documentation website
-   ~~~ sh
-   sbt "+publishSigned" sonatypeReleaseAll "++ 2.13 manual/makeSite" manual/ghpagesPushSite
-   ~~~
-6. Create a tag `vx.y.z`
-   ~~~ sh
-   git tag vx.y.z
-   ~~~
-7. Reset the compatibility intention to `Compatibility.BinaryAndSourceCompatible`,
-   and add a `+n` suffix to the version of every module (e.g., change `1.0.0`
-   into `1.0.0+n`). In case a module used its own value for `versionPolicyIntention`
-   instead of reusing the one defined at the build level, comment it out.
-8. Commit the changes
+5. Manually reset the compatibility intention of all the modules to `Compatibility.BinaryAndSourceCompatible`.
+   In case a module used its own value for `versionPolicyIntention` instead of reusing the one defined at the
+   build level, comment it out.
+6. Commit the changes
    ~~~ sh
    git commit -a -m "Reset compatibility intention"
    ~~~
-9. Push
+7. Push
    ~~~ sh
-   git push --tags origin master
+   git push origin master
    ~~~
-10. Publish the release notes on GitHub
+8. Publish the release notes on GitHub
 
 ## Breakage policy
 
 Our goal is to publish backward binary compatible releases of the algebra modules for as long
 as possible. It is OK to break compatibility in interpreter modules, but if possible we
-should keep backward compatibility.
+should keep backwards compatibility.
 
 So, algebra and interpreters have different version numbers and compatibility guarantees
 across releases.
@@ -167,9 +144,7 @@ After every release, the level of compatibility is reset to `Compatibility.Binar
 in every module.
 
 If necessary, we can relax this constraint to `Compatibility.BinaryCompatible` in modules that
-need to introduce potential source incompatibilities. In such a case, we can also preset the
-version number of the module (e.g., we can change `1.0.0+n` into `1.1.0`).
+need to introduce potential source incompatibilities.
 
 If necessary, we can relax this constraint to `Compatibility.None` in interpreter modules that
-need to break binary compatibility. In such a case, we can also preset the version number of
-the module (e.g., we can change `1.0.0+n` into `2.0.0`).
+need to break binary compatibility.

--- a/akka-http/build.sbt
+++ b/akka-http/build.sbt
@@ -13,7 +13,6 @@ val `akka-http-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "akka-http-client",
-      version := "5.3.0+n",
       publish / skip := scalaBinaryVersion.value.startsWith("3"),
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-stream" % akkaActorVersion % Provided).cross(CrossVersion.for3Use2_13),
@@ -41,7 +40,6 @@ val `akka-http-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "akka-http-server",
-      version := "7.1.0+n",
       publish / skip := scalaBinaryVersion.value.startsWith("3"),
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-http" % akkaHttpVersion).cross(CrossVersion.for3Use2_13),

--- a/algebras/build.sbt
+++ b/algebras/build.sbt
@@ -26,7 +26,6 @@ val `algebra-testkit` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "algebra-testkit",
-      version := "4.0.0+n",
       publish / skip := scalaBinaryVersion.value.startsWith("3"),
       libraryDependencies ++= Seq(
         ("com.typesafe.akka" %% "akka-http" % akkaHttpVersion).cross(CrossVersion.for3Use2_13),
@@ -54,7 +53,6 @@ val `algebra-circe` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "algebra-circe",
-      version := "2.3.0+n",
       libraryDependencies ++= Seq(
         "io.circe" %%% "circe-parser" % circeVersion,
         "io.circe" %%% "circe-generic" % circeVersion % Test
@@ -75,7 +73,6 @@ val `algebra-circe-testkit` =
       `scala 2.12 to dotty`,
       name := "algebra-circe-testkit",
       publish / skip := scalaBinaryVersion.value.startsWith("3"),
-      version := "4.0.0+n",
       libraryDependencies ++= Seq()
     )
     .dependsOn(`algebra-circe`, `algebra-testkit`)

--- a/documentation/build.sbt
+++ b/documentation/build.sbt
@@ -37,6 +37,7 @@ val apiDoc =
     .enablePlugins(ScalaUnidocPlugin)
     .settings(
       noPublishSettings,
+      version := (`algebra-jvm` / version).value,
       `scala 2.13`,
       coverageEnabled := false,
       ScalaUnidoc / unidoc / scalacOptions ++= Seq(
@@ -82,6 +83,7 @@ val manual =
     .settings(
       noPublishSettings,
       `scala 2.13`,
+      version := (`algebra-jvm` / version).value,
       coverageEnabled := false,
       git.remoteRepo := "git@github.com:endpoints4s/endpoints4s.github.io.git",
       ghpagesBranch := "master",

--- a/fetch/build.sbt
+++ b/fetch/build.sbt
@@ -10,7 +10,6 @@ val `fetch-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "fetch-client",
-      version := "3.0.0+n",
       mimaBinaryIssueFilters ++= Seq(
         // Was private to Scala users
         ProblemFilters.exclude[DirectMissingMethodProblem]("endpoints4s.fetch.EndpointsSettings.this")
@@ -52,7 +51,6 @@ val `fetch-client-circe` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "fetch-client-circe",
-      version := "3.0.0+n",
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies += "io.circe" %%% "circe-parser" % circeVersion,

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -19,7 +19,6 @@ val `http4s-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-server",
-      version := "10.1.0+n",
       libraryDependencies ++= Seq(
         "org.http4s" %% "http4s-core" % http4sVersion,
         "org.http4s" %% "http4s-dsl" % http4sVersion,
@@ -40,7 +39,6 @@ val `http4s-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-client",
-      version := "6.3.0+n",
       libraryDependencies ++= Seq(
         "org.http4s" %%% "http4s-client" % http4sVersion
       )

--- a/json-schema/build.sbt
+++ b/json-schema/build.sbt
@@ -32,7 +32,6 @@ val `json-schema-testkit` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "algebra-json-schema-testkit",
-      version := "2.0.0+n",
       libraryDependencies ++= Seq(
         "org.scalatest" %%% "scalatest" % scalaTestVersion,
         "io.github.cquiroz" %%% "scala-java-time" % "2.4.0",
@@ -83,7 +82,6 @@ lazy val `json-schema-circe` =
       `scala 2.12 to dotty`,
       publishSettings,
       name := "json-schema-circe",
-      version := "2.3.0+n",
       libraryDependencies += "io.circe" %%% "circe-core" % circeVersion,
       (Compile / boilerplateSource) := baseDirectory.value / ".." / "src" / "main" / "boilerplate"
     )

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -13,7 +13,6 @@ lazy val openapi =
     .crossType(CrossType.Pure)
     .in(file("openapi"))
     .settings(
-      version := "4.3.0+n",
       publishSettings,
       `scala 2.12 to dotty`,
       name := "openapi",

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -1,7 +1,7 @@
 import sbt._
 import sbt.Keys._
+import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport.versionPolicyIntention
 import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
-import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport.mimaPreviousArtifacts
 
 object EndpointsSettings {
 
@@ -85,6 +85,13 @@ object EndpointsSettings {
     homepage := Some(url(s"https://github.com/endpoints4s/endpoints4s")),
     licenses := Seq(
       "MIT License" -> url("http://opensource.org/licenses/mit-license.php")
+    ),
+    version := Versioning.computeVersion(
+      name.value,
+      crossVersion.value,
+      scalaBinaryVersion.value,
+      scalaVersion.value,
+      versionPolicyIntention.value
     )
   )
 

--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -1,0 +1,59 @@
+import coursierapi.{Module, Versions}
+import sbt.librarymanagement.CrossVersion
+import sbtrelease.Version
+import sbtversionpolicy.Compatibility
+
+object Versioning {
+
+  private val versions = Versions.create()
+
+  /**
+    * @param module             Module name (without “cross-version suffix”), e.g. "algebra"
+    * @param crossVersion       CrossVersion of the module
+    * @param scalaBinaryVersion Scala binary version
+    * @param scalaFullVersion   Scala full version
+    * @return The latest stable release of the module.
+    */
+  def lastVersion(module: String, crossVersion: CrossVersion, scalaBinaryVersion: String, scalaFullVersion: String): String = {
+    val artifactName =
+      CrossVersion(crossVersion, scalaFullVersion, scalaBinaryVersion)
+        .getOrElse(sys.error(s"Unable to compute the artifact name of the module ${module}"))
+        .apply(module)
+    versions
+      .withModule(Module.of("org.endpoints4s", artifactName))
+      .versions()
+      .getMergedListings
+      .getRelease
+      .ensuring(_.nonEmpty, s"No release found for module ${module}")
+  }
+
+  /**
+    * @return The version of the given module such that it complies with the
+    *         intended compatibility guarantees.
+    *
+    * By default, it adds the suffix "+n" to the latest release version of the module.
+    * However, in “release mode” (if the environment variable `RELEASE` is set to `true`)
+    * it computes the release version by bumping the appropriate version numbers
+    * according to the intended compatibility guarantees.
+    *
+    * It is possible to add a qualifier to the computed version by setting the environment
+    * variable `VERSION_QUALIFIER`. For instance `VERSION_QUALIFIER="-RC1"`
+    */
+  def computeVersion(module: String, crossVersion: CrossVersion, scalaBinaryVersion: String, scalaFullVersion: String, compatibility: Compatibility): String = {
+    val rawVersion = lastVersion(module, crossVersion, scalaBinaryVersion, scalaFullVersion)
+    val last = Version(rawVersion).getOrElse(sys.error(s"Unable to parse the version of module ${module}: ${rawVersion}"))
+    if (sys.env.get("RELEASE").contains("true")) {
+      val qualifier = sys.env.getOrElse("VERSION_QUALIFIER", "")
+      val bumpedVersion =
+        compatibility match {
+          case Compatibility.None => last.bumpMajor
+          case Compatibility.BinaryCompatible => last.bumpMinor
+          case Compatibility.BinaryAndSourceCompatible => last.bumpBugfix
+        }
+      bumpedVersion.string + qualifier
+    } else {
+      last.string + "+n"
+    }
+  }
+
+}

--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -19,12 +19,14 @@ object Versioning {
       CrossVersion(crossVersion, scalaFullVersion, scalaBinaryVersion)
         .getOrElse(sys.error(s"Unable to compute the artifact name of the module ${module}"))
         .apply(module)
-    versions
-      .withModule(Module.of("org.endpoints4s", artifactName))
-      .versions()
-      .getMergedListings
-      .getRelease
-      .ensuring(_.nonEmpty, s"No release found for module ${module}")
+    val version =
+      versions
+        .withModule(Module.of("org.endpoints4s", artifactName))
+        .versions()
+        .getMergedListings
+        .getRelease
+    if (version.isEmpty) "0.0.0" // fallback in case the module has not been published yet
+    else version
   }
 
   /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,10 +13,8 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % sbtCrossPr
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
-
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.3")

--- a/sttp/build.sbt
+++ b/sttp/build.sbt
@@ -12,7 +12,6 @@ val `sttp-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "sttp-client",
-      version := "5.3.0+n",
       libraryDependencies ++= Seq(
         "com.softwaremill.sttp.client3" %% "core" % sttpVersion,
         ("com.softwaremill.sttp.client3" %% "akka-http-backend" % sttpVersion % Test).cross(CrossVersion.for3Use2_13),

--- a/stub-server/build.sbt
+++ b/stub-server/build.sbt
@@ -7,7 +7,6 @@ val `stub-server` =
       publishSettings,
       `scala 2.13`,
       name := "stub-server",
-      version := "2.0.0+n",
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
         "com.typesafe.akka" %% "akka-stream" % akkaActorVersion

--- a/xhr/build.sbt
+++ b/xhr/build.sbt
@@ -10,7 +10,6 @@ val `xhr-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "xhr-client",
-      version := "5.2.0+n",
       mimaBinaryIssueFilters ++= Seq(
         // Was private to Scala users
         ProblemFilters.exclude[DirectMissingMethodProblem]("endpoints4s.xhr.EndpointsSettings.this")
@@ -54,7 +53,6 @@ val `xhr-client-faithful` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "xhr-client-faithful",
-      version := "5.2.0+n",
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies += ("org.julienrf" %%% "faithful" % "2.0.0")
@@ -87,7 +85,6 @@ val `xhr-client-circe` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "xhr-client-circe",
-      version := "5.2.0+n",
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies += "io.circe" %%% "circe-parser" % circeVersion,


### PR DESCRIPTION
- Compute the modules’ versions from their previous stable release (fetched with Coursier) and their intended compatibility level
- Add a Release workflow that publishes all the modules to Sonatype
- Update documentation accordingly