### PR TITLE
Make OpenApi.jsonEncoder public

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ ThisBuild / version := (LocalProject("algebraJVM") / version).value
 // We want to keep binary compatibility as long as we can for the algebra,
 // but it is OK to publish breaking releases of interpreters. So,
 // interpreter modules may override this setting.
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // Ignore dependencies to modules with version like `1.2.3+n`
 ThisBuild / versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+n".r)
 

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/model/OpenApi.scala
@@ -411,7 +411,7 @@ object OpenApi {
   private def pathsJson(paths: collection.Map[String, PathItem]): ujson.Obj =
     mapJson(paths)(pathItem => mapJson(pathItem.operations)(operationJson))
 
-  private val jsonEncoder: Encoder[OpenApi, ujson.Value] =
+  val jsonEncoder: Encoder[OpenApi, ujson.Value] =
     openApi => {
       val fields: mutable.LinkedHashMap[String, ujson.Value] =
         mutable.LinkedHashMap(


### PR DESCRIPTION
To serialize the json using a non-default ujson renderer, e.g. to produce indented output, I need access to the json structure. Right now the only way to do this is to re-parse the output of `stringEncoder`.