### PR TITLE
OpenApi for `application/octet-stream` should have type=string, format=binary

### DIFF
--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/ChunkedEntities.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/ChunkedEntities.scala
@@ -19,7 +19,7 @@ trait ChunkedEntities extends algebra.ChunkedEntities with EndpointsWithCustomEr
   def textChunksResponse: ResponseEntity[Chunks[String]] = textChunksEntity
 
   private lazy val bytesChunksEntity =
-    Map("application/octet-stream" -> MediaType(None))
+    Map("application/octet-stream" -> MediaType(Some(Schema.simpleString.withFormat(Some("binary")))))
 
   def bytesChunksRequest: RequestEntity[Chunks[Array[Byte]]] = bytesChunksEntity
 


### PR DESCRIPTION
[OAPI reference](https://swagger.io/docs/specification/data-models/data-types/#file) specifies this for 'files' i.e. opaque binary request/response bodies.

The previous value of `MediaType(None)` means anything is allowed, which is technically correct; but Swagger Codegen refuses to parse a schema that doesn't have a `type` specified, and if I specify `type="string"`, then `format="binary"` is also required for the schema to mean the right thing. (This might have changed in the latest swagger-codegen release.)