### PR TITLE
Update ujson to `3.2.0`

### DIFF
--- a/algebras/build.sbt
+++ b/algebras/build.sbt
@@ -26,7 +26,7 @@ val `algebra-testkit` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "algebra-testkit",
-//      versionPolicyIntention := Compatibility.None,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
         "org.apache.pekko" %% "pekko-actor" % pekkoActorVersion,
@@ -43,9 +43,9 @@ val `algebra-testkit` =
     .dependsOnLocalCrossProjectsWithNative("json-schema-testkit")
     .configurePlatforms(JSPlatform, NativePlatform)(_.disablePlugins(ScoverageSbtPlugin))
 
-val `algebra-testkit-js` = algebra.js
-val `algebra-testkit-jvm` = algebra.jvm
-val `algebra-testkit-native` = algebra.native
+val `algebra-testkit-js` = `algebra-testkit`.js
+val `algebra-testkit-jvm` = `algebra-testkit`.jvm
+val `algebra-testkit-native` = `algebra-testkit`.native
 
 val `algebra-circe` =
   crossProject(JSPlatform, JVMPlatform)
@@ -74,7 +74,7 @@ val `algebra-circe-testkit` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "algebra-circe-testkit",
-//      versionPolicyIntention := Compatibility.None,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq()
     )
     .dependsOn(`algebra-circe`, `algebra-testkit`)

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ ThisBuild / version := (LocalProject("algebraJVM") / version).value
 // We want to keep binary compatibility as long as we can for the algebra,
 // but it is OK to publish breaking releases of interpreters. So,
 // interpreter modules may override this setting.
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.BinaryCompatible
 // Ignore dependencies to modules with version like `1.2.3+n`
 ThisBuild / versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+n".r)
 

--- a/fetch/build.sbt
+++ b/fetch/build.sbt
@@ -10,6 +10,7 @@ val `fetch-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "fetch-client",
+      versionPolicyIntention := Compatibility.None,
       mimaBinaryIssueFilters ++= Seq(
         // Was private to Scala users
         ProblemFilters.exclude[DirectMissingMethodProblem](
@@ -53,6 +54,7 @@ val `fetch-client-circe` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "fetch-client-circe",
+      versionPolicyIntention := Compatibility.None,
       //disable coverage for scala.js: https://github.com/scoverage/scalac-scoverage-plugin/issues/196
       coverageEnabled := false,
       libraryDependencies += "io.circe" %%% "circe-parser" % circeVersion,

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -19,6 +19,7 @@ val `http4s-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-server",
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.http4s" %% "http4s-core" % http4sVersion,
         "org.http4s" %% "http4s-dsl" % http4sVersion,
@@ -39,6 +40,7 @@ val `http4s-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "http4s-client",
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.http4s" %%% "http4s-client" % http4sVersion
       )

--- a/openapi/build.sbt
+++ b/openapi/build.sbt
@@ -16,6 +16,7 @@ lazy val openapi =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "openapi",
+      versionPolicyIntention := Compatibility.None,
       (Compile / boilerplateSource) := (Compile / baseDirectory).value / ".." / "src" / "main" / "boilerplate",
       libraryDependencies += "com.lihaoyi" %%% "ujson" % ujsonVersion,
     )

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/model/OpenApi.scala
@@ -112,7 +112,7 @@ object OpenApi {
 
         val required = obj.properties.filter(_.isRequired).map(_.name)
         if (required.nonEmpty) {
-          result.value.put("required", ujson.Arr(required))
+          result.value.put("required", ujson.Arr.from(required))
         }
         obj.additionalProperties.foreach(p =>
           result.value.put("additionalProperties", schemaJson(p))
@@ -275,7 +275,7 @@ object OpenApi {
     if (operation.parameters.nonEmpty) {
       obj.value.put(
         "parameters",
-        ujson.Arr(
+        ujson.Arr.from(
           operation.parameters.map(parameterJson)
         )
       )

--- a/openapi/openapi/src/main/scala/endpoints4s/openapi/model/OpenApi.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/openapi/model/OpenApi.scala
@@ -3,8 +3,6 @@ package endpoints4s.openapi.model
 import endpoints4s.algebra.{ExternalDocumentationObject, Tag}
 import endpoints4s.{Encoder, Hashing}
 
-import scala.collection.mutable
-
 /** @see [[https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md]]
   * @note Throws an exception on creation if several tags have the same name but not the same other attributes.
   */
@@ -70,64 +68,64 @@ object OpenApi {
   ): OpenApi =
     new OpenApi(info, paths, components, servers)
 
-  private def mapJson[A](map: collection.Map[String, A])(f: A => ujson.Value): ujson.Obj =
-    new ujson.Obj(mutable.LinkedHashMap(map.iterator.map { case (k, v) =>
-      (k, f(v))
-    }.toSeq: _*))
+  private def mapJson[A](map: collection.Map[String, A])(f: A => ujson.Value): ujson.Obj = {
+    val result = ujson.Obj()
+    map.foreach { case (k, v) => result.value.put(k, f(v)) }
+    result
+  }
 
   private[openapi] def schemaJson(schema: Schema): ujson.Obj = {
-    val fields = mutable.LinkedHashMap.empty[String, ujson.Value]
+    val result = ujson.Obj()
 
     for (description <- schema.description) {
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
     for (example <- schema.example) {
-      fields += "example" -> example
+      result.value.put("example", example)
     }
     for (title <- schema.title) {
-      fields += "title" -> title
+      result.value.put("title", title)
     }
     for (default <- schema.default) {
-      fields += "default" -> default
+      result.value.put("default", default)
     }
 
     schema match {
       case primitive: Schema.Primitive =>
-        fields += "type" -> ujson.Str(primitive.name)
-        primitive.format.foreach(s => fields += "format" -> ujson.Str(s))
-        primitive.minimum.foreach(d => fields += "minimum" -> ujson.Num(d))
-        primitive.exclusiveMinimum.foreach(b => fields += "exclusiveMinimum" -> ujson.Bool(b))
-        primitive.maximum.foreach(d => fields += "maximum" -> ujson.Num(d))
-        primitive.exclusiveMaximum.foreach(b => fields += "exclusiveMaximum" -> ujson.Bool(b))
-        primitive.multipleOf.foreach(d => fields += "multipleOf" -> ujson.Num(d))
+        result.value.put("type", ujson.Str(primitive.name))
+        primitive.format.foreach(s => result.value.put("format", ujson.Str(s)))
+        primitive.minimum.foreach(d => result.value.put("minimum", ujson.Num(d)))
+        primitive.exclusiveMinimum.foreach(b => result.value.put("exclusiveMinimum", ujson.Bool(b)))
+        primitive.maximum.foreach(d => result.value.put("maximum", ujson.Num(d)))
+        primitive.exclusiveMaximum.foreach(b => result.value.put("exclusiveMaximum", ujson.Bool(b)))
+        primitive.multipleOf.foreach(d => result.value.put("multipleOf", ujson.Num(d)))
       case obj: Schema.Object =>
-        fields ++= List(
-          "type" -> "object",
-          "properties" -> new ujson.Obj(
-            mutable.LinkedHashMap(
-              obj.properties.map { (p: Schema.Property) =>
-                val schema = p.schema
-                  .withDefinedDescription(p.description)
-                  .withDefinedDefault(p.defaultValue)
-                p.name -> schemaJson(schema)
-              }: _*
-            )
-          )
-        )
+        result.value.put("type", "object")
+        val properties = ujson.Obj()
+        obj.properties.foreach { (p: Schema.Property) =>
+          val schema = p.schema
+            .withDefinedDescription(p.description)
+            .withDefinedDefault(p.defaultValue)
+          properties.value.put(p.name, schemaJson(schema))
+        }
+        result.value.put("properties", properties)
+
         val required = obj.properties.filter(_.isRequired).map(_.name)
         if (required.nonEmpty) {
-          fields += "required" -> ujson.Arr(required.map(ujson.Str): _*)
+          result.value.put("required", ujson.Arr(required))
         }
-        obj.additionalProperties.foreach(p => fields += "additionalProperties" -> schemaJson(p))
+        obj.additionalProperties.foreach(p =>
+          result.value.put("additionalProperties", schemaJson(p))
+        )
       case array: Schema.Array =>
-        fields += "type" -> "array"
+        result.value.put("type", "array")
         array.elementType match {
           case Left(value) =>
-            fields += "items" -> schemaJson(value)
+            result.value.put("items", schemaJson(value))
           case Right(value) =>
             // Best effort (not 100% accurate) to represent the heterogeneous array in OpenAPI 3.0
             // This should be changed with OpenAPI 3.1 and more idiomatic representation using `prefixItems`
-            fields ++= List(
+            result.value ++= List(
               "items" -> schemaJson(
                 Schema.OneOf(
                   alternatives = Schema.EnumeratedAlternatives(value),
@@ -141,42 +139,39 @@ object OpenApi {
             )
         }
       case enm: Schema.Enum =>
-        fields ++= schemaJson(
+        result.value ++= schemaJson(
           enm.elementType.withDefinedDescription(enm.description)
         ).value
-        fields += "enum" -> ujson.Arr(enm.values: _*)
+        result.value.put("enum", ujson.Arr.from(enm.values))
       case oneOf: Schema.OneOf =>
-        fields ++=
+        result.value ++=
           (oneOf.alternatives match {
             case discAlternatives: Schema.DiscriminatedAlternatives =>
-              val mappingFields: mutable.LinkedHashMap[String, ujson.Value] =
-                mutable.LinkedHashMap(discAlternatives.alternatives.collect {
-                  case (tag, ref: Schema.Reference) =>
-                    tag -> ujson.Str(Schema.Reference.toRefPath(ref.name))
-                }: _*)
-              val discFields = mutable.LinkedHashMap.empty[String, ujson.Value]
-              discFields += "propertyName" -> ujson.Str(
+              val mapping = ujson.Obj()
+              discAlternatives.alternatives.foreach {
+                case (tag, ref: Schema.Reference) =>
+                  mapping.value.put(tag, ujson.Str(Schema.Reference.toRefPath(ref.name)))
+                case _ =>
+              }
+              val discriminator = ujson.Obj()
+              discriminator.value += "propertyName" -> ujson.Str(
                 discAlternatives.discriminatorFieldName
               )
-              if (mappingFields.nonEmpty) {
-                discFields += "mapping" -> new ujson.Obj(mappingFields)
+              if (mapping.value.nonEmpty) {
+                discriminator.value += "mapping" -> mapping
               }
               List(
-                "oneOf" -> ujson
-                  .Arr(
-                    discAlternatives.alternatives
-                      .map(kv => schemaJson(kv._2)): _*
-                  ),
-                "discriminator" -> ujson.Obj(discFields)
+                "oneOf" ->
+                  ujson.Arr.from(discAlternatives.alternatives.map(kv => schemaJson(kv._2))),
+                "discriminator" -> discriminator
               )
             case enumAlternatives: Schema.EnumeratedAlternatives =>
               List(
-                "oneOf" -> ujson
-                  .Arr(enumAlternatives.alternatives.map(schemaJson): _*)
+                "oneOf" -> ujson.Arr.from(enumAlternatives.alternatives.map(schemaJson))
               )
           })
       case allOf: Schema.AllOf =>
-        fields += "allOf" -> ujson.Arr(allOf.schemas.map(schemaJson): _*)
+        result.value.put("allOf", ujson.Arr.from(allOf.schemas.map(schemaJson)))
       case reference: Schema.Reference =>
         /* In OpenAPI 3.0 (and 2.0), reference schemas are special in that all
          * their sibling values are ignored!
@@ -188,46 +183,43 @@ object OpenApi {
          * See <https://stackoverflow.com/a/41752575/3072788>.
          */
         val refSchemaName = ujson.Str(Schema.Reference.toRefPath(reference.name))
-        if (fields.isEmpty) {
-          fields += "$ref" -> refSchemaName
+        if (result.value.isEmpty) {
+          result.value.put("$ref", refSchemaName)
         } else {
-          fields += "allOf" -> ujson.Arr(ujson.Obj("$ref" -> refSchemaName))
+          result.value.put("allOf", ujson.Arr(ujson.Obj("$ref" -> refSchemaName)))
         }
     }
 
-    new ujson.Obj(fields)
+    result
   }
 
   private def securitySchemeJson(securityScheme: SecurityScheme): ujson.Obj = {
-    val fields = mutable.LinkedHashMap[String, ujson.Value](
-      "type" -> ujson.Str(securityScheme.`type`)
-    )
+    val result = ujson.Obj()
+    result.value.put("type", ujson.Str(securityScheme.`type`))
     for (description <- securityScheme.description) {
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
     for (name <- securityScheme.name) {
-      fields += "name" -> ujson.Str(name)
+      result.value.put("name", ujson.Str(name))
     }
     for (in <- securityScheme.in) {
-      fields += "in" -> ujson.Str(in)
+      result.value.put("in", ujson.Str(in))
     }
     for (scheme <- securityScheme.scheme) {
-      fields += "scheme" -> ujson.Str(scheme)
+      result.value.put("scheme", ujson.Str(scheme))
     }
     for (bearerFormat <- securityScheme.bearerFormat) {
-      fields += "bearerFormat" -> ujson.Str(bearerFormat)
+      result.value.put("bearerFormat", ujson.Str(bearerFormat))
     }
-    new ujson.Obj(fields)
+    result
   }
 
   private def infoJson(info: Info): ujson.Obj = {
-    val fields: mutable.LinkedHashMap[String, ujson.Value] =
-      mutable.LinkedHashMap(
-        "title" -> ujson.Str(info.title),
-        "version" -> ujson.Str(info.version)
-      )
-    info.description.foreach(description => fields += "description" -> ujson.Str(description))
-    ujson.Obj(fields)
+    val result = ujson.Obj()
+    result.value.put("title", ujson.Str(info.title))
+    result.value.put("version", ujson.Str(info.version))
+    info.description.foreach(description => result.value.put("description", ujson.Str(description)))
+    result
   }
 
   private def componentsJson(components: Components): ujson.Obj =
@@ -239,29 +231,27 @@ object OpenApi {
     )
 
   private def responseJson(response: Response): ujson.Obj = {
-    val fields = mutable.LinkedHashMap[String, ujson.Value](
-      "description" -> ujson.Str(response.description)
-    )
+    val result = ujson.Obj()
+    result.value.put("description", ujson.Str(response.description))
     if (response.headers.nonEmpty) {
-      fields += "headers" -> mapJson(response.headers)(responseHeaderJson)
+      result.value.put("headers", mapJson(response.headers)(responseHeaderJson))
     }
     if (response.content.nonEmpty) {
-      fields += "content" -> mapJson(response.content)(mediaTypeJson)
+      result.value.put("content", mapJson(response.content)(mediaTypeJson))
     }
-    new ujson.Obj(fields)
+    result
   }
 
   def responseHeaderJson(responseHeader: ResponseHeader): ujson.Value = {
-    val fields = mutable.LinkedHashMap[String, ujson.Value](
-      "schema" -> schemaJson(responseHeader.schema)
-    )
+    val result = ujson.Obj()
+    result.value.put("schema", schemaJson(responseHeader.schema))
     if (responseHeader.required) {
-      fields += "required" -> ujson.True
+      result.value.put("required", ujson.True)
     }
     responseHeader.description.foreach { description =>
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
-    new ujson.Obj(fields)
+    result
   }
 
   def mediaTypeJson(mediaType: MediaType): ujson.Value =
@@ -271,58 +261,60 @@ object OpenApi {
     }
 
   private def operationJson(operation: Operation): ujson.Obj = {
-    val fields = mutable.LinkedHashMap[String, ujson.Value](
-      "responses" -> mapJson(operation.responses)(responseJson)
-    )
+    val obj = ujson.Obj()
+    obj.value.put("responses", mapJson(operation.responses)(responseJson))
     operation.operationId.foreach { id =>
-      fields += "operationId" -> ujson.Str(id)
+      obj.value.put("operationId", ujson.Str(id))
     }
     operation.summary.foreach { summary =>
-      fields += "summary" -> ujson.Str(summary)
+      obj.value.put("summary", ujson.Str(summary))
     }
     operation.description.foreach { description =>
-      fields += "description" -> ujson.Str(description)
+      obj.value.put("description", ujson.Str(description))
     }
     if (operation.parameters.nonEmpty) {
-      fields += "parameters" -> ujson.Arr(
-        operation.parameters.map(parameterJson): _*
+      obj.value.put(
+        "parameters",
+        ujson.Arr(
+          operation.parameters.map(parameterJson)
+        )
       )
     }
     operation.requestBody.foreach { requestBody =>
-      fields += "requestBody" -> requestBodyJson(requestBody)
+      obj.value.put("requestBody", requestBodyJson(requestBody))
     }
     if (operation.tags.nonEmpty) {
-      fields += "tags" -> ujson.Arr(
-        operation.tags.map(tag => ujson.Str(tag.name)): _*
-      )
+      val tags = ujson.Arr()
+      operation.tags.foreach(tag => tags.value += ujson.Str(tag.name))
+      obj.value.put("tags", tags)
     }
     if (operation.security.nonEmpty) {
-      fields += "security" -> ujson.Arr(
-        operation.security.map(securityRequirementJson): _*
-      )
+      val security = ujson.Arr()
+      operation.security.foreach(item => security.value += securityRequirementJson(item))
+      obj.value.put("security", security)
     }
     if (operation.callbacks.nonEmpty) {
-      fields += "callbacks" -> mapJson(operation.callbacks)(pathsJson)
+      obj.value.put("callbacks", mapJson(operation.callbacks)(pathsJson))
     }
     if (operation.deprecated) {
-      fields += "deprecated" -> ujson.True
+      obj.value.put("deprecated", ujson.True)
     }
-    new ujson.Obj(fields)
+    obj
   }
 
   private def parameterJson(parameter: Parameter): ujson.Value = {
-    val fields = mutable.LinkedHashMap[String, ujson.Value](
+    val result = ujson.Obj(
       "name" -> ujson.Str(parameter.name),
       "in" -> inJson(parameter.in),
       "schema" -> schemaJson(parameter.schema)
     )
     parameter.description.foreach { description =>
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
     if (parameter.required) {
-      fields += "required" -> ujson.True
+      result.value.put("required", ujson.True)
     }
-    new ujson.Obj(fields)
+    result
   }
 
   private def inJson(in: In): ujson.Value =
@@ -334,78 +326,71 @@ object OpenApi {
     }
 
   private def requestBodyJson(body: RequestBody): ujson.Value = {
-    val fields = mutable.LinkedHashMap[String, ujson.Value](
-      "content" -> mapJson(body.content)(mediaTypeJson)
-    )
+    val result = ujson.Obj()
+    result.value.put("content", mapJson(body.content)(mediaTypeJson))
     body.description.foreach { description =>
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
-    new ujson.Obj(fields)
+    result
   }
 
   private def tagJson(tag: Tag): ujson.Value = {
-    val fields: mutable.LinkedHashMap[String, ujson.Value] =
-      mutable.LinkedHashMap(
-        "name" -> ujson.Str(tag.name)
-      )
+    val result = ujson.Obj()
+    result.value.put("name", ujson.Str(tag.name))
 
-    if (tag.description.nonEmpty) {
-      fields += "description" -> tag.description.get
+    for (description <- tag.description) {
+      result.value.put("description", description)
     }
-    if (tag.externalDocs.nonEmpty) {
-      fields += "externalDocs" -> externalDocumentationObjectJson(
-        tag.externalDocs.get
-      )
+    for (externalDocs <- tag.externalDocs) {
+      result.value.put("externalDocs", externalDocumentationObjectJson(externalDocs))
     }
-    new ujson.Obj(fields)
+    result
   }
 
   private def serverJson(server: Server): ujson.Value = {
-    val fields: mutable.LinkedHashMap[String, ujson.Value] = mutable.LinkedHashMap(
-      "url" -> ujson.Str(server.url)
-    )
+    val result = ujson.Obj()
+    result.value.put("url", ujson.Str(server.url))
     for (description <- server.description) {
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
     if (server.variables.nonEmpty) {
-      fields += "variables" -> mapJson(server.variables)(serverVariableJson)
+      result.value.put("variables", mapJson(server.variables)(serverVariableJson))
     }
-    ujson.Obj(fields)
+    result
   }
 
   private def serverVariableJson(variable: ServerVariable): ujson.Value = {
-    val fields: mutable.LinkedHashMap[String, ujson.Value] = mutable.LinkedHashMap(
-      "default" -> ujson.Str(variable.default)
-    )
+    val result = ujson.Obj()
+    result.value.put("default", ujson.Str(variable.default))
     for (description <- variable.description) {
-      fields += "description" -> ujson.Str(description)
+      result.value.put("description", ujson.Str(description))
     }
     for (alternatives <- variable.`enum`) {
-      fields += "enum" -> ujson.Arr(alternatives.map(alternative => ujson.Str(alternative)): _*)
+      result.value.put(
+        "enum",
+        ujson.Arr.from(alternatives.map(alternative => ujson.Str(alternative)))
+      )
     }
-    ujson.Obj(fields)
+    result
   }
 
   private def externalDocumentationObjectJson(
       externalDoc: ExternalDocumentationObject
   ): ujson.Value = {
-    val fields: mutable.LinkedHashMap[String, ujson.Value] =
-      mutable.LinkedHashMap(
-        "url" -> ujson.Str(externalDoc.url)
-      )
-
-    if (externalDoc.description.nonEmpty)
-      fields += "description" -> externalDoc.description.get
-    new ujson.Obj(fields)
+    val result = ujson.Obj(
+      "url" -> ujson.Str(externalDoc.url)
+    )
+    for (description <- externalDoc.description) {
+      result.value.put("description", description)
+    }
+    result
   }
 
   private def securityRequirementJson(
       securityRequirement: SecurityRequirement
   ): ujson.Value =
     ujson.Obj(
-      securityRequirement.name -> ujson.Arr(
-        securityRequirement.scopes.map(ujson.Str): _*
-      )
+      securityRequirement.name -> ujson.Arr.from(securityRequirement.scopes.map(ujson.Str))
     )
 
   private def pathsJson(paths: collection.Map[String, PathItem]): ujson.Obj =
@@ -413,24 +398,24 @@ object OpenApi {
 
   val jsonEncoder: Encoder[OpenApi, ujson.Value] =
     openApi => {
-      val fields: mutable.LinkedHashMap[String, ujson.Value] =
-        mutable.LinkedHashMap(
-          "openapi" -> ujson.Str(openApiVersion),
-          "info" -> infoJson(openApi.info),
-          "paths" -> pathsJson(openApi.innerPaths)
-        )
+      val result = ujson.Obj()
+      result.value.put("openapi", ujson.Str(openApiVersion))
+      result.value.put("info", infoJson(openApi.info))
+      result.value.put("paths", pathsJson(openApi.innerPaths))
+
       if (openApi.servers.nonEmpty) {
-        val serversAsJson = openApi.servers.map(server => serverJson(server))
-        fields += "servers" -> ujson.Arr(serversAsJson: _*)
+        val servers = ujson.Arr()
+        openApi.servers.foreach(server => servers.value += serverJson(server))
+        result.value.put("servers", servers)
       }
       if (openApi.tags.nonEmpty) {
         val tagsAsJson = openApi.tags.map(tag => tagJson(tag)).toList
-        fields += "tags" -> ujson.Arr(tagsAsJson: _*)
+        result.value.put("tags", ujson.Arr.from(tagsAsJson))
       }
       if (openApi.components.schemas.nonEmpty || openApi.components.securitySchemes.nonEmpty) {
-        fields += "components" -> componentsJson(openApi.components)
+        result.value.put("components", componentsJson(openApi.components))
       }
-      new ujson.Obj(fields)
+      result.value
     }
 
   private def extractTags(paths: collection.Map[String, PathItem]): Set[Tag] = {

--- a/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
+++ b/openapi/openapi/src/main/scala/endpoints4s/ujson/JsonSchemas.scala
@@ -4,7 +4,6 @@ import endpoints4s.algebra.JsonSchemas.PreciseField
 import endpoints4s.{ujson => _, _}
 
 import scala.collection.compat._
-import scala.collection.mutable
 
 /** @group interpreters
   */
@@ -351,9 +350,10 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
 
         def encode(from: t.Out): ujson.Obj = {
           val (a, b) = t.unapply(from)
-          new ujson.Obj(
-            recordA.encoder.encode(a).value ++ recordB.encoder.encode(b).value
-          )
+          val result = ujson.Obj()
+          result.value ++= recordA.encoder.encode(a).value
+          result.value ++= recordB.encoder.encode(b).value
+          result
         }
       }
     }
@@ -553,9 +553,11 @@ trait JsonSchemas extends algebra.NoDocsJsonSchemas with TuplesSchemas {
       }
 
       val encoder = map => {
-        new ujson.Obj(mutable.LinkedHashMap(map.map { case (k, v) =>
-          (k, jsonSchema.codec.encode(v))
-        }.toSeq: _*))
+        val result = ujson.Obj()
+        map.foreach { case (k, v) =>
+          result.value.put(k, jsonSchema.codec.encode(v))
+        }
+        result
       }
     }
 }

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/ReferencedSchemaTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/ReferencedSchemaTest.scala
@@ -65,16 +65,6 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |        ]
         |      },
         |      "post" : {
-        |        "requestBody" : {
-        |          "content" : {
-        |            "application/json" : {
-        |              "schema" : {
-        |                "$ref" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Book"
-        |              }
-        |            }
-        |          },
-        |          "description" : "Books list"
-        |        },
         |        "responses" : {
         |          "400" : {
         |            "description" : "Client error",
@@ -108,6 +98,16 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |            "description" : ""
         |          }
         |        },
+        |        "requestBody" : {
+        |          "content" : {
+        |            "application/json" : {
+        |              "schema" : {
+        |                "$ref" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Book"
+        |              }
+        |            }
+        |          },
+        |          "description" : "Books list"
+        |        },
         |        "tags" : [
         |          "Books",
         |          "Another tag"
@@ -133,10 +133,6 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |  ],
         |  "components" : {
         |    "schemas" : {
-        |      "Color" : {
-        |        "type" : "string",
-        |        "enum" : ["Red", "Blue"]
-        |      },
         |      "endpoints4s.openapi.ReferencedSchemaTest.Storage.Online" : {
         |        "type" : "object",
         |        "properties" : {
@@ -153,6 +149,23 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |          "storageType",
         |          "link"
         |        ]
+        |      },
+        |      "endpoints4s.openapi.ReferencedSchemaTest.Storage" : {
+        |        "oneOf" : [
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Library"
+        |          },
+        |          {
+        |            "$ref" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Online"
+        |          }
+        |        ],
+        |        "discriminator" : {
+        |          "propertyName" : "storageType",
+        |          "mapping" : {
+        |            "Library" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Library",
+        |            "Online" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Online"
+        |          }
+        |        }
         |      },
         |      "endpoints4s.openapi.ReferencedSchemaTest.Book" : {
         |        "type" : "object",
@@ -196,22 +209,9 @@ class ReferencedSchemaTest extends AnyWordSpec with Matchers {
         |          "storage"
         |        ]
         |      },
-        |      "endpoints4s.openapi.ReferencedSchemaTest.Storage" : {
-        |        "oneOf" : [
-        |          {
-        |            "$ref" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Library"
-        |          },
-        |          {
-        |            "$ref" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Online"
-        |          }
-        |        ],
-        |        "discriminator" : {
-        |          "propertyName" : "storageType",
-        |          "mapping" : {
-        |            "Library" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Library",
-        |            "Online" : "#/components/schemas/endpoints4s.openapi.ReferencedSchemaTest.Storage.Online"
-        |          }
-        |        }
+        |      "Color" : {
+        |        "type" : "string",
+        |        "enum" : ["Red", "Blue"]
         |      },
         |      "endpoints.Errors" : {
         |        "type" : "array",

--- a/openapi/openapi/src/test/scala/endpoints4s/openapi/WebhooksTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/openapi/WebhooksTest.scala
@@ -58,16 +58,6 @@ class WebhooksTest extends AnyWordSpec with Matchers {
         |  "paths" : {
         |    "/subscribe" : {
         |      "post" : {
-        |        "parameters" : [
-        |          {
-        |            "name" : "callbackURL",
-        |            "in" : "query",
-        |            "schema" : {
-        |              "type" : "string"
-        |            },
-        |            "required" : true
-        |          }
-        |        ],
         |        "responses" : {
         |          "400" : {
         |            "description" : "Client error",
@@ -93,6 +83,16 @@ class WebhooksTest extends AnyWordSpec with Matchers {
         |            "description" : ""
         |          }
         |        },
+        |        "parameters" : [
+        |          {
+        |            "name" : "callbackURL",
+        |            "in" : "query",
+        |            "schema" : {
+        |              "type" : "string"
+        |            },
+        |            "required" : true
+        |          }
+        |        ],
         |        "callbacks" : {
         |          "message" : {
         |            "{$request.query.callbackURL}" : {

--- a/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasOptionalFieldsTest.scala
+++ b/openapi/openapi/src/test/scala/endpoints4s/ujson/JsonSchemasOptionalFieldsTest.scala
@@ -3,8 +3,6 @@ package endpoints4s.ujson
 import endpoints4s.{Validated, algebra}
 import org.scalatest.freespec.AnyFreeSpec
 
-import scala.collection.mutable
-
 class JsonSchemasOptionalFieldsTest
     extends AnyFreeSpec
     with algebra.JsonSchemasOptionalFieldsTest
@@ -14,9 +12,8 @@ class JsonSchemasOptionalFieldsTest
 
   object Json extends Json {
     type Json = ujson.Value
-    def obj(fields: (String, Json)*): Json =
-      ujson.Obj(new mutable.LinkedHashMap ++= fields)
-    def arr(items: Json*): Json = ujson.Arr(items: _*)
+    def obj(fields: (String, Json)*): Json = ujson.Obj.from(fields)
+    def arr(items: Json*): Json = ujson.Arr.from(items)
     def num(x: BigDecimal): Json = ujson.Num(x.doubleValue)
     def str(s: String): Json = ujson.Str(s)
     def bool(b: Boolean): Json = ujson.Bool(b)
@@ -40,9 +37,8 @@ class JsonSchemasOptionalFieldsNoValueTest
 
   object Json extends Json {
     type Json = ujson.Value
-    def obj(fields: (String, Json)*): Json =
-      ujson.Obj(new mutable.LinkedHashMap ++= fields)
-    def arr(items: Json*): Json = ujson.Arr(items: _*)
+    def obj(fields: (String, Json)*): Json = ujson.Obj.from(fields)
+    def arr(items: Json*): Json = ujson.Arr.from(items)
     def num(x: BigDecimal): Json = ujson.Num(x.doubleValue)
     def str(s: String): Json = ujson.Str(s)
     def bool(b: Boolean): Json = ujson.Bool(b)

--- a/pekko-http/build.sbt
+++ b/pekko-http/build.sbt
@@ -13,7 +13,7 @@ val `pekko-http-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "pekko-http-client",
-//      versionPolicyIntention := Compatibility.None,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.apache.pekko" %% "pekko-stream" % pekkoActorVersion % Provided,
         "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
@@ -40,7 +40,7 @@ val `pekko-http-server` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "pekko-http-server",
-//      versionPolicyIntention := Compatibility.None,
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
         "org.apache.pekko" %% "pekko-stream" % pekkoActorVersion % Provided,

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -113,7 +113,7 @@ object EndpointsSettings {
   val pekkoHttpVersion = "1.0.0"
   val http4sVersion = "0.23.6"
   val http4sDomVersion = "0.2.3"
-  val ujsonVersion = "1.4.0"
+  val ujsonVersion = "3.1.4"
 
   val scalaTestVersion = "3.2.17"
   val scalaTestDependency =

--- a/project/EndpointsSettings.scala
+++ b/project/EndpointsSettings.scala
@@ -113,7 +113,7 @@ object EndpointsSettings {
   val pekkoHttpVersion = "1.0.0"
   val http4sVersion = "0.23.6"
   val http4sDomVersion = "0.2.3"
-  val ujsonVersion = "3.1.4"
+  val ujsonVersion = "3.2.0"
 
   val scalaTestVersion = "3.2.17"
   val scalaTestDependency =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0"
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.1.1"
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.15.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % sbtCrossProjectVersion)
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.16")

--- a/sttp/build.sbt
+++ b/sttp/build.sbt
@@ -12,6 +12,7 @@ val `sttp-client` =
       publishSettings,
       `scala 2.12 to dotty`,
       name := "sttp-client",
+      versionPolicyIntention := Compatibility.None,
       libraryDependencies ++= Seq(
         "com.softwaremill.sttp.client3" %% "core" % sttpVersion,
         "com.softwaremill.sttp.client3" %% "httpclient-backend" % sttpVersion % Test


### PR DESCRIPTION
The version of `ujson` currently used is ancient and creates conflicts when endpoints4s is used together with other libraries depending on newer `upickle` or `geny`.
Moreover ujson `3+` fixes a DOS vulnerability (more info here https://github.com/com-lihaoyi/upickle/pull/449)